### PR TITLE
HARVESTER:fix:No disk shows up when plugging a new disk to add to host

### DIFF
--- a/edit/host/index.vue
+++ b/edit/host/index.vue
@@ -126,7 +126,7 @@ export default {
 
           if ((!findBy(this.disks || [], 'name', d.metadata.name) &&
                 d?.spec?.nodeName === this.value.id &&
-                addedToNodeCondition?.status === 'False' &&
+                (!addedToNodeCondition || addedToNodeCondition?.status === 'False') &&
                 !d.spec?.fileSystem?.provisioned &&
                 !isAdded) ||
                 isRemoved


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/1208

`addedToNodeCondition` is false when the disk has not been added to the node.