### PR TITLE
Tweak a number of items from Dashboard review

### DIFF
--- a/assets/styles/themes/_light.scss
+++ b/assets/styles/themes/_light.scss
@@ -311,7 +311,7 @@ BODY, .theme-light {
   --header-height              : 55px;
   --header-border              : #{$medium};
   --header-border-size         : 1px;
-  --nav-width                  : 260px;
+  --nav-width                  : 230px;
   --nav-bg                     : #{$lightest};
   --nav-active                 : #{$light};
   --nav-hover                  : #{$medium};

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -5211,6 +5211,7 @@ typeDescription:
   logging.banzaicloud.io.flow: A flow defines which logs to collect and filter as well as which output to send the logs. The flow is a namespaced resource, which means logs will only be collected from the namepsace that the flow is deployed in.
   logging.banzaicloud.io.output: An output defines which logging providers that logs can be sent to. The output needs to be in the same namespace as the flow that is using it.
   group.principal: Assigning global roles to a group only works with external auth providers that support groups. Local authorization does not support groups.
+  harvesterhci.io.management.cluster: Virtualization Management is in Tech Preview.
 
 typeLabel:
   management.cattle.io.token: |-

--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -166,7 +166,7 @@ export default {
     },
 
     parent() {
-      const displayName = this.value.displayNameOverride || this.$store.getters['type-map/labelFor'](this.schema);
+      const displayName = this.value.parentNameOverride || this.$store.getters['type-map/labelFor'](this.schema);
       const product = this.$store.getters['currentProduct'].name;
 
       const defaultLocation = {

--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -277,15 +277,14 @@ export default {
   created() {
     // eslint-disable-next-line prefer-const
     const id = this.$route.params.id;
-    let resource = this.resourceOverride || this.$route.params.resource;
+    const resource = this.resourceOverride || this.$route.params.resource;
     const options = this.$store.getters[`type-map/optionsFor`](resource);
 
-    if ( options.resource && !options?.useCustomInImport ) {
-      resource = options.resource;
-    }
+    const detailResource = options.resourceDetail || options.resource || resource;
+    const editResource = options.resourceEdit || options.resource || resource;
 
-    this.detailComponent = this.$store.getters['type-map/importDetail'](resource, id);
-    this.editComponent = this.$store.getters['type-map/importEdit'](resource, id);
+    this.detailComponent = this.$store.getters['type-map/importDetail'](detailResource, id);
+    this.editComponent = this.$store.getters['type-map/importEdit'](editResource, id);
   },
 
   methods: {

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -393,7 +393,7 @@ export default {
 
 <style lang="scss" scoped>
   $clear-search-size: 20px;
-  $icon-size: 24px;
+  $icon-size: 25px;
   $option-padding: 4px;
   $option-height: $icon-size + $option-padding + $option-padding;
 
@@ -415,6 +415,7 @@ export default {
     }
 
     > i {
+      width: $icon-size;
       font-size: $icon-size;
       margin-right: 8px;
     }

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -171,7 +171,7 @@ export default {
 
       if (el) {
         const $el = $(el);
-        const h = 32 * max;
+        const h = 33 * max;
 
         $el.css('height', `${ h }px`);
       }

--- a/config/product/harvester-manager.js
+++ b/config/product/harvester-manager.js
@@ -27,6 +27,7 @@ export function init(store) {
   } = DSL(store, NAME);
 
   product({
+    ifHaveType:          CAPI.RANCHER_CLUSTER,
     ifFeature:           MULTI_CLUSTER,
     inStore:             'management',
     icon:                'harvester',

--- a/config/product/harvester-manager.js
+++ b/config/product/harvester-manager.js
@@ -1,5 +1,5 @@
 import { HCI, MANAGEMENT, VIRTUAL_HARVESTER_PROVIDER, CAPI } from '@/config/types';
-import { MULTI_CLUSTER } from '@/store/features';
+import { HARVESTER, MULTI_CLUSTER } from '@/store/features';
 import { DSL } from '@/store/type-map';
 import { STATE, NAME as NAME_COL, AGE, VERSION } from '@/config/table-headers';
 import { allHash } from '@/utils/promise';
@@ -28,7 +28,7 @@ export function init(store) {
 
   product({
     ifHaveType:          CAPI.RANCHER_CLUSTER,
-    ifFeature:           MULTI_CLUSTER,
+    ifFeature:           [MULTI_CLUSTER, HARVESTER],
     inStore:             'management',
     icon:                'harvester',
     removable:           false,

--- a/config/product/harvester.js
+++ b/config/product/harvester.js
@@ -1,5 +1,5 @@
 import {
-  HCI, NODE, CONFIG_MAP, NAMESPACE, VIRTUAL_TYPES, MANAGEMENT, PVC
+  HCI, NODE, CONFIG_MAP, NAMESPACE, VIRTUAL_TYPES, MANAGEMENT, PVC, CAPI
 } from '@/config/types';
 import {
   STATE, NAME_UNLINKED, NAME as NAME_COL, AGE, NAMESPACE_COL,
@@ -7,7 +7,7 @@ import {
 
 import { IMAGE_DOWNLOAD_SIZE, FINGERPRINT, IMAGE_PROGRESS } from '@/config/harvester-table-headers';
 
-import { DSL } from '@/store/type-map';
+import { DSL, IF_HAVE } from '@/store/type-map';
 
 export const NAME = 'harvester';
 
@@ -61,6 +61,7 @@ export function init(store) {
 
   configureType(HCI.HOST, { isCreatable: false, isEditable: true });
   basicType([HCI.HOST]);
+
   virtualType({
     ifHaveType:    NODE,
     label:         store.getters['i18n/t']('harvester.host.label'),
@@ -80,9 +81,7 @@ export function init(store) {
     'cluster-members',
   ], 'rbac');
   virtualType({
-    showMenuFun(state, getters, rootState, rootGetters) {
-      return rootGetters['isMultiCluster'];
-    },
+    ifHave:     IF_HAVE.MULTI_CLUSTER,
     label:       store.getters['i18n/t']('members.clusterMembers'),
     group:      'root',
     namespaced:  false,
@@ -150,9 +149,7 @@ export function init(store) {
 
   basicType(['projects-namespaces']);
   virtualType({
-    showMenuFun(state, getters, rootState, rootGetters) {
-      return rootGetters['isMultiCluster'];
-    },
+    ifHave:     IF_HAVE.MULTI_CLUSTER,
     label:            'Projects/Namespaces',
     group:            'root',
     namespaced:       true,
@@ -166,9 +163,7 @@ export function init(store) {
   headers(NAMESPACE, [STATE, NAME_UNLINKED, AGE]);
   basicType([NAMESPACE]);
   virtualType({
-    showMenuFun(state, getters, rootState, rootGetters) {
-      return rootGetters['isSingleVirtualCluster'];
-    },
+    ifHave:     IF_HAVE.HARVESTER_SINGLE_CLUSTER,
     label:                  store.getters['i18n/t'](`typeLabel.${ NAMESPACE }`, { count: 2 }),
     name:                   NAMESPACE,
     namespaced:             true,
@@ -265,21 +260,13 @@ export function init(store) {
   // settings
   configureType(HCI.SETTING, { isCreatable: false });
   virtualType({
-    showMenuFun(state, getters, rootState, rootGetters, out) {
-      const schema = rootGetters['harvester/schemaFor'](HCI.SETTING);
-
-      if (schema?.collectionMethods.find(x => x.toLowerCase() === 'post')) {
-        return true;
-      }
-      // TODO: use cb
-      delete out[HCI.SETTING];
-
-      return false;
-    },
+    ifHaveType:          HCI.SETTING,
+    ifHaveVerb:          'POST',
     label:      store.getters['i18n/t']('harvester.setting.label'),
     name:       HCI.SETTING,
     namespaced: true,
     weight:     -1,
+    icon:       'folder',
     route:      {
       name:     'c-cluster-product-resource',
       params:   { resource: HCI.SETTING }

--- a/config/product/harvester.js
+++ b/config/product/harvester.js
@@ -1,5 +1,5 @@
 import {
-  HCI, NODE, CONFIG_MAP, NAMESPACE, VIRTUAL_TYPES, MANAGEMENT, PVC, CAPI
+  HCI, NODE, CONFIG_MAP, NAMESPACE, VIRTUAL_TYPES, MANAGEMENT, PVC
 } from '@/config/types';
 import {
   STATE, NAME_UNLINKED, NAME as NAME_COL, AGE, NAMESPACE_COL,
@@ -55,8 +55,9 @@ export function init(store) {
       name:    'c-cluster-product-resource',
       params:  { resource: HCI.HOST },
     },
-    resource:          NODE,
-    useCustomInImport: true
+    resource:       NODE,
+    resourceDetail: HCI.HOST,
+    resourceEdit:   HCI.HOST,
   });
 
   configureType(HCI.HOST, { isCreatable: false, isEditable: true });
@@ -115,8 +116,9 @@ export function init(store) {
       name:    'c-cluster-product-resource',
       params:  { resource: HCI.VOLUME },
     },
-    resource:          PVC,
-    useCustomInImport: true
+    resource:       PVC,
+    resourceDetail: HCI.VOLUME,
+    resourceEdit:   HCI.VOLUME,
   });
   virtualType({
     label:      store.getters['i18n/t']('harvester.volume.label'),
@@ -242,8 +244,9 @@ export function init(store) {
       name:    'c-cluster-product-resource',
       params:  { resource: HCI.CLOUD_TEMPLATE },
     },
-    resource:          CONFIG_MAP,
-    useCustomInImport: true
+    resource:       CONFIG_MAP,
+    resourceDetail: HCI.CLOUD_TEMPLATE,
+    resourceEdit:   HCI.CLOUD_TEMPLATE,
   });
   virtualType({
     label:        store.getters['i18n/t']('harvester.cloudTemplate.label'),

--- a/edit/harvesterhci.io.cloudtemplate.vue
+++ b/edit/harvesterhci.io.cloudtemplate.vue
@@ -10,7 +10,7 @@ import CreateEditView from '@/mixins/create-edit-view';
 import { HCI } from '@/config/labels-annotations';
 
 export default {
-  name: 'EditCloudTemplate',
+  name: 'HarvesterEditCloudTemplate',
 
   components: {
     Tab,

--- a/edit/harvesterhci.io.host/index.vue
+++ b/edit/harvesterhci.io.host/index.vue
@@ -20,7 +20,7 @@ import { exceptionToErrorsArray } from '@/utils/error';
 import HarvesterDisk from './HarvesterDisk';
 
 export default {
-  name:       'EditNode',
+  name:       'HarvesterEditNode',
   components: {
     Footer,
     Tabbed,

--- a/edit/harvesterhci.io.keypair.vue
+++ b/edit/harvesterhci.io.keypair.vue
@@ -10,7 +10,7 @@ import { randomStr } from '@/utils/string';
 import CreateEditView from '@/mixins/create-edit-view';
 
 export default {
-  name: 'EditSSH',
+  name: 'HarvesterEditKeypair',
 
   components: {
     Tab,

--- a/edit/harvesterhci.io.setting/backup-target.vue
+++ b/edit/harvesterhci.io.setting/backup-target.vue
@@ -6,7 +6,7 @@ import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 
 export default {
-  name: 'HarvesterBackupTarget',
+  name: 'HarvesterEditBackupTarget',
 
   components: {
     LabeledInput, LabeledSelect, Tip, Password

--- a/edit/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/edit/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -21,7 +21,7 @@ import VM_MIXIN from '@/mixins/harvester-vm';
 import CreateEditView from '@/mixins/create-edit-view';
 
 export default {
-  name: 'EditVMTemplate',
+  name: 'HarvesterEditVMTemplate',
 
   components: {
     Tab,

--- a/edit/harvesterhci.io.volume.vue
+++ b/edit/harvesterhci.io.volume.vue
@@ -16,7 +16,7 @@ import CreateEditView from '@/mixins/create-edit-view';
 import { HCI as HCI_ANNOTATIONS } from '@/config/labels-annotations';
 
 export default {
-  name: 'Volume',
+  name: 'HarvesterVolume',
 
   components: {
     Tab,

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineCpuMemory.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineCpuMemory.vue
@@ -4,7 +4,7 @@ import UnitInput from '@/components/form/UnitInput';
 import InputOrDisplay from '@/components/InputOrDisplay';
 
 export default {
-  name:       'CpuMemory',
+  name:       'HarvesterEditCpuMemory',
   components: { UnitInput, InputOrDisplay },
 
   props:      {

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineNetwork/base.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineNetwork/base.vue
@@ -29,7 +29,7 @@ export const MODEL = [{
 }];
 
 export default {
-  name:       'Network',
+  name:       'HarvesterEditNetwork',
   components: {
     LabeledInput, LabeledSelect, InputOrDisplay
   },

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/index.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/index.vue
@@ -232,7 +232,7 @@ export default {
     <Banner v-if="!isView" color="info" label-key="harvester.virtualMachine.volume.dragTip" />
     <draggable v-model="rows" @end="update">
       <transition-group>
-        <div v-for="(volume, i) in rows" :key="i">
+        <div v-for="(volume, i) in rows" :key="volume.to.params.id">
           <InfoBox class="volume-source">
             <button v-if="!isView" type="button" class="role-link btn btn-sm remove-vol" @click="removeVolume(volume)">
               <i class="icon icon-2x icon-x" />

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/container.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/container.vue
@@ -4,7 +4,7 @@ import LabeledSelect from '@/components/form/LabeledSelect';
 import InputOrDisplay from '@/components/InputOrDisplay';
 
 export default {
-  name:       'Container',
+  name:       'HarvesterEditContainer',
   components: {
     LabeledInput, LabeledSelect, InputOrDisplay
   },

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/existing.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/existing.vue
@@ -10,7 +10,7 @@ import { HCI, PVC } from '@/config/types';
 import { HCI as HCI_ANNOTATIONS } from '@/config/labels-annotations';
 
 export default {
-  name:       'Existing',
+  name:       'HarvesterEditExisting',
   components: {
     Banner, UnitInput, LabeledInput, LabeledSelect, InputOrDisplay
   },

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -7,7 +7,7 @@ import InputOrDisplay from '@/components/InputOrDisplay';
 import { HCI, PVC } from '@/config/types';
 
 export default {
-  name: 'VMImage',
+  name: 'HarvesterEditVMImage',
 
   components: {
     Banner, UnitInput, LabeledInput, LabeledSelect, InputOrDisplay

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
@@ -9,7 +9,7 @@ import LabeledSelect from '@/components/form/LabeledSelect';
 import { PVC } from '@/config/types';
 
 export default {
-  name:       'Volume',
+  name:       'HarvesterEditVolume',
   components: {
     Banner, InputOrDisplay, Loading, LabeledInput, LabeledSelect, UnitInput,
   },

--- a/edit/kubevirt.io.virtualmachine/index.vue
+++ b/edit/kubevirt.io.virtualmachine/index.vue
@@ -28,7 +28,7 @@ import VM_MIXIN from '@/mixins/harvester-vm';
 import CreateEditView from '@/mixins/create-edit-view';
 
 export default {
-  name: 'EditVM',
+  name: 'HarvesterEditVM',
 
   components: {
     Tab,

--- a/edit/management.cattle.io.fleetworkspace.vue
+++ b/edit/management.cattle.io.fleetworkspace.vue
@@ -12,7 +12,7 @@ import { SCOPE_NAMESPACE, SCOPE_CLUSTER } from '@/components/RoleBindings.vue';
 import { NAME as FLEET_NAME } from '@/config/product/fleet';
 
 export default {
-  name: 'CruWorkspace',
+  name: 'FleetCruWorkspace',
 
   components: {
     CruResource,

--- a/list/harvesterhci.io.dashboard/HarvesterUpgrade.vue
+++ b/list/harvesterhci.io.dashboard/HarvesterUpgrade.vue
@@ -8,7 +8,7 @@ import LabeledSelect from '@/components/form/LabeledSelect';
 import Banner from '@/components/Banner';
 
 export default {
-  name: 'HarvesterUpgrade',
+  name: 'HarvesterListUpgrade',
 
   components: {
     ModalWithCard, LabeledSelect, Banner

--- a/list/harvesterhci.io.management.cluster.vue
+++ b/list/harvesterhci.io.management.cluster.vue
@@ -1,11 +1,17 @@
 <script>
+import TypeDescription from '@/components/TypeDescription';
 import ResourceTable from '@/components/ResourceTable';
 import Masthead from '@/components/ResourceList/Masthead';
 import { NAME as VIRTUAL } from '@/config/product/harvester';
-import { CAPI } from '@/config/types';
+import { CAPI, HCI } from '@/config/types';
 
 export default {
-  components: { ResourceTable, Masthead },
+  components: {
+    ResourceTable,
+    Masthead,
+    TypeDescription
+  },
+
   props:      {
     schema: {
       type:     Object,
@@ -24,6 +30,7 @@ export default {
     return {
       VIRTUAL,
       resource,
+      hResource:  HCI.CLUSTER,
       realSchema: this.$store.getters['management/schemaFor'](CAPI.RANCHER_CLUSTER),
     };
   },
@@ -59,6 +66,8 @@ export default {
       </template>
     </Masthead>
 
+    <TypeDescription :resource="hResource" />
+
     <ResourceTable
       :schema="schema"
       :rows="rows"
@@ -89,19 +98,11 @@ export default {
 
       <template #cell:harvester="{row}">
         <n-link
-          v-if="row.isReady"
           class="btn btn-sm role-primary"
           :to="row.detailLocation"
         >
           {{ t('harvester.virtualizationManagement.manage') }}
         </n-link>
-        <button
-          v-else
-          :disabled="true"
-          class="btn btn-sm role-primary"
-        >
-          {{ t('harvester.virtualizationManagement.manage') }}
-        </button>
       </template>
     </ResourceTable>
   </div>

--- a/models/harvester/configmap.js
+++ b/models/harvester/configmap.js
@@ -2,10 +2,6 @@ import { clone } from '@/utils/object';
 import { HCI } from '@/config/types';
 
 export default {
-  displayNameOverride() {
-    return this.$rootGetters['i18n/t'](`typeLabel."${ HCI.CLOUD_TEMPLATE }"`, { count: 1 });
-  },
-
   detailLocation() {
     const detailLocation = clone(this._detailLocation);
 
@@ -23,6 +19,10 @@ export default {
     detailLocation.name = 'c-cluster-product-resource';
 
     return detailLocation;
+  },
+
+  parentNameOverride() {
+    return this.$rootGetters['i18n/t'](`typeLabel."${ HCI.CLOUD_TEMPLATE }"`, { count: 1 })?.trim();
   },
 
   parentLocationOverride() {

--- a/models/harvester/node.js
+++ b/models/harvester/node.js
@@ -6,10 +6,6 @@ import findLast from 'lodash/findLast';
 import { colorForState, stateDisplay } from '@/plugins/steve/resource-instance';
 
 export default {
-  displayNameOverride() {
-    return this.$rootGetters['i18n/t'](`typeLabel."${ HCI.HOST }"`, { count: 1 });
-  },
-
   _availableActions() {
     const cordon = {
       action:     'cordon',
@@ -105,6 +101,10 @@ export default {
     detailLocation.name = 'c-cluster-product-resource';
 
     return detailLocation;
+  },
+
+  parentNameOverride() {
+    return this.$rootGetters['i18n/t'](`typeLabel."${ HCI.HOST }"`, { count: 1 })?.trim();
   },
 
   parentLocationOverride() {

--- a/models/harvester/persistentvolumeclaim.js
+++ b/models/harvester/persistentvolumeclaim.js
@@ -5,9 +5,6 @@ import { HCI as HCI_ANNOTATIONS } from '@/config/labels-annotations';
 import { get, clone } from '@/utils/object';
 
 export default {
-  displayNameOverride() {
-    return this.$rootGetters['i18n/t'](`typeLabel."${ HCI.VOLUME }"`, { count: 1 });
-  },
 
   applyDefaults() {
     return (_, realMode) => {
@@ -55,6 +52,10 @@ export default {
     detailLocation.name = 'c-cluster-product-resource';
 
     return detailLocation;
+  },
+
+  parentNameOverride() {
+    return this.$rootGetters['i18n/t'](`typeLabel."${ HCI.VOLUME }"`, { count: 1 }).trim();
   },
 
   parentLocationOverride() {

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -91,6 +91,9 @@
 //                               showState: true,  -- If false, hide state in columns and masthead
 //                               showAge: true,    -- If false, hide age in columns and masthead
 //                               canYaml: true,
+//                               resource: undefined       -- Use this resource in ResourceDetails instead
+//                               resourceDetail: undefined -- Use this resource specifically for ResourceDetail's detail component
+//                               resourceEdit: undefined   -- Use this resource specifically for ResourceDetail's edit component
 //                           }
 // )
 // ignoreGroup(group):        Never show group or any types in it

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -1187,8 +1187,14 @@ export const getters = {
         }
       }
 
-      if ( p.ifFeature && !rootGetters['features/get'](p.ifFeature) ) {
-        return false;
+      if ( p.ifFeature) {
+        const features = Array.isArray(p.ifFeature) ? p.ifFeature : [p.ifFeature];
+
+        for (const f of features) {
+          if (!rootGetters['features/get'](f)) {
+            return false;
+          }
+        }
       }
 
       if ( p.ifHave && !ifHave(rootGetters, p.ifHave)) {

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -112,7 +112,7 @@ import { AGE, NAME, NAMESPACE, STATE } from '@/config/table-headers';
 import { COUNT, SCHEMA, MANAGEMENT } from '@/config/types';
 import { DEV, EXPANDED_GROUPS, FAVORITE_TYPES } from '@/store/prefs';
 import {
-  addObject, findBy, insertAt, isArray, removeObject
+  addObject, findBy, insertAt, isArray, removeObject, filterBy
 } from '@/utils/array';
 import { clone, get } from '@/utils/object';
 import {
@@ -145,10 +145,12 @@ export const SPOOFED_API_PREFIX = '__[[spoofedapi]]__';
 const instanceMethods = {};
 
 export const IF_HAVE = {
-  V1_MONITORING: 'v1-monitoring',
-  V2_MONITORING: 'v2-monitoring',
-  PROJECT:       'project',
-  NO_PROJECT:    'no-project',
+  V1_MONITORING:            'v1-monitoring',
+  V2_MONITORING:            'v2-monitoring',
+  PROJECT:                  'project',
+  NO_PROJECT:               'no-project',
+  MULTI_CLUSTER:            'multi-cluster',
+  HARVESTER_SINGLE_CLUSTER: 'harv-multi-cluster',
 };
 
 export function DSL(store, product, module = 'type-map') {
@@ -776,6 +778,12 @@ export const getters = {
           const id = item.name;
           const weight = type.weight || getters.typeWeightFor(item.label, isBasic);
 
+          // Is there a virtual/spoofed type override for schema type?
+          // Currently used by harvester, this should be investigated and removed if possible
+          if (out[id]) {
+            delete out[id];
+          }
+
           if ( item['public'] === false && !isDev ) {
             continue;
           }
@@ -788,7 +796,13 @@ export const getters = {
             const targetedSchemas = typeof item.ifHaveType === 'string' ? schemas : rootGetters[`${ item.ifHaveType.store }/all`](SCHEMA);
             const type = typeof item.ifHaveType === 'string' ? item.ifHaveType : item.ifHaveType?.type;
 
-            if (!findBy(targetedSchemas, 'id', normalizeType(type))) {
+            const haveIds = filterBy(targetedSchemas, 'id', normalizeType(type)).map(s => s.id);
+
+            if (!haveIds.length) {
+              continue;
+            }
+
+            if (item.ifHaveVerb && !ifHaveVerb(rootGetters, module, item.ifHaveVerb, haveIds)) {
               continue;
             }
           }
@@ -804,10 +818,6 @@ export const getters = {
           }
 
           if ( typeof item.ifRancherCluster !== 'undefined' && item.ifRancherCluster !== rootGetters.isRancher ) {
-            continue;
-          }
-
-          if (item.showMenuFun && typeof item.showMenuFun === 'function' && !item.showMenuFun(state, getters, rootState, rootGetters, out)) {
             continue;
           }
 
@@ -1189,22 +1199,8 @@ export const getters = {
           return false;
         }
 
-        if ( p.ifHaveVerb ) {
-          let found = false;
-
-          for ( const haveId of haveIds ) {
-            const schema = rootGetters[`${ module }/schemaFor`](haveId);
-            const want = p.ifHaveVerb.toLowerCase();
-            const have = [...schema.collectionMethods, ...schema.resourceMethods].map(x => x.toLowerCase());
-
-            if ( have.includes(want) || have.includes(`blocked-${ want }`) ) {
-              found = true;
-            }
-          }
-
-          if ( !found ) {
-            return false;
-          }
+        if ( p.ifHaveVerb && !ifHaveVerb(rootGetters, module, p.ifHaveVerb, haveIds)) {
+          return false;
         }
       }
 
@@ -1601,9 +1597,29 @@ function ifHave(getters, option) {
   case IF_HAVE.NO_PROJECT: {
     return !project(getters);
   }
+  case IF_HAVE.MULTI_CLUSTER: {
+    return getters.isMultiCluster;
+  }
+  case IF_HAVE.HARVESTER_SINGLE_CLUSTER: {
+    return getters.isSingleVirtualCluster;
+  }
   default:
     return false;
   }
+}
+
+function ifHaveVerb(rootGetters, module, verb, haveIds) {
+  for ( const haveId of haveIds ) {
+    const schema = rootGetters[`${ module }/schemaFor`](haveId);
+    const want = verb.toLowerCase();
+    const have = [...schema.collectionMethods, ...schema.resourceMethods].map(x => x.toLowerCase());
+
+    if ( !have.includes(want) && !have.includes(`blocked-${ want }`) ) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 // Look at the namespace filters to determine if a project is selected


### PR DESCRIPTION
- Fixed some low hanging fruit (side nav width, icon sizing, component names)
- Fixed SSR issues when working with virtualType showMenuFun
- Only show `Virtualisation Management` link if user has access to provisioning clusters AND the harvester feature flag is enabled
- Fixed a couple of Dashboard 'todo's regarding how virtualType resources are used
- Fixed warning on build
- Add a tech preview notice as per https://github.com/rancher/dashboard/issues/4028
- Fix issue where cluster's `Manage` button was disabled if the cluster wasn't up yet (user could not see reg command)

See each commit messages for more detail

I hope the code looks good, but it really needs another test mostly when in single cluster mode

 