### PR TITLE
Harvester:fix:Additional disk is not visible unless manually formatted

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4885,6 +4885,11 @@ harvester:
         label: Scheduling
       evictionRequested:
         label: Eviction Requested
+      forceFormatted:
+        label: Force Formatted
+        toolTip: Force formatted will cleanup disk data, make sure you backup all available data to prevent data loss.
+      description:
+        label: Description
 
   virtualizationManagement:
     manage: Manage

--- a/assets/translations/zh-hans.yaml
+++ b/assets/translations/zh-hans.yaml
@@ -3961,6 +3961,10 @@ harvester:
       add: 添加硬盘
       path:
         label: 路径
+      forceFormatted:
+        label: 格式化
+      description:
+        label: 描述
 
   virtualizationManagement:
     manage: 管理

--- a/detail/harvesterhci.io.host/HarvesterHostDisk.vue
+++ b/detail/harvesterhci.io.host/HarvesterHostDisk.vue
@@ -1,14 +1,10 @@
 <script>
-import LabeledInput from '@/components/form/LabeledInput';
-import UnitInput from '@/components/form/UnitInput';
 import LabelValue from '@/components/LabelValue';
 import BadgeState from '@/components/BadgeState';
 import Banner from '@/components/Banner';
 
 export default {
   components: {
-    LabeledInput,
-    UnitInput,
     LabelValue,
     BadgeState,
     Banner,
@@ -123,15 +119,19 @@ export default {
         </div>
       </div>
       <div v-if="!value.isNew" class="row mt-30">
-        <div class="col flex span-12">
+        <div class="col span-4">
           <LabelValue
             name="Storage Available"
             :value="value.storageAvailable"
           />
+        </div>
+        <div class="col span-4">
           <LabelValue
             name="Storage Scheduled"
             :value="value.storageScheduled"
           />
+        </div>
+        <div class="col span-4">
           <LabelValue
             name="Storage Max"
             :value="value.storageMaximum"
@@ -141,32 +141,26 @@ export default {
       <hr class="mt-10" />
     </div>
     <div class="row mt-10">
-      <div class="col span-6">
-        <LabeledInput
-          v-model="value.displayName"
-          :label="t('generic.name')"
-          :disabled="true"
+      <div class="col span-4">
+        <LabelValue
+          :name="t('generic.name')"
+          :value="value.displayName"
         />
       </div>
-      <div class="col span-6">
-        <LabeledInput
-          v-model="value.path"
-          :label="t('harvester.host.disk.path.label')"
-          :disabled="true"
-          required
+      <div class="col span-4">
+        <LabelValue
+          :name="t('harvester.host.disk.path.label')"
+          :value="value.path"
         />
       </div>
-    </div>
-    <div v-if="false" class="row mt-10">
-      <div class="col span-6">
-        <UnitInput
-          v-model="value.storageReserved"
-          v-int-number
-          suffix="GiB"
-          label-key="harvester.host.disk.storageReserved.label"
-          :mode="mode"
-          :disabled="true"
-        />
+      <div class="col span-4">
+        <LabelValue
+          :name="t('harvester.host.disk.forceFormatted.label')"
+        >
+          <template #value>
+            {{ value.forceFormatted ? t('generic.yes') : t('generic.no') }}
+          </template>
+        </LabelValue>
       </div>
     </div>
   </div>

--- a/detail/harvesterhci.io.host/index.vue
+++ b/detail/harvesterhci.io.host/index.vue
@@ -61,12 +61,13 @@ export default {
     })
       .map((d) => {
         return {
-          isNew:       true,
-          name:        d?.metadata?.name,
-          originPath:  d?.spec?.fileSystem?.mountPoint,
-          path:        d?.spec?.fileSystem?.mountPoint,
-          blockDevice: d,
-          displayName: d?.spec?.devPath,
+          isNew:          true,
+          name:           d?.metadata?.name,
+          originPath:     d?.spec?.fileSystem?.mountPoint,
+          path:           d?.spec?.fileSystem?.mountPoint,
+          blockDevice:    d,
+          displayName:    d?.spec?.devPath,
+          forceFormatted: d?.spec?.fileSystem?.forceFormatted || false,
         };
       });
 
@@ -115,6 +116,7 @@ export default {
           storageScheduled: formatSi(diskStatus[key]?.storageScheduled, formatOptions),
           blockDevice,
           displayName:      blockDevice?.spec?.devPath || key,
+          forceFormatted:   blockDevice?.spec?.fileSystem?.forceFormatted || false,
         };
       });
 

--- a/edit/harvesterhci.io.host/HarvesterDisk.vue
+++ b/edit/harvesterhci.io.host/HarvesterDisk.vue
@@ -1,17 +1,17 @@
 <script>
 import LabeledInput from '@/components/form/LabeledInput';
-import UnitInput from '@/components/form/UnitInput';
 import LabelValue from '@/components/LabelValue';
 import BadgeState from '@/components/BadgeState';
 import Banner from '@/components/Banner';
+import RadioGroup from '@/components/form/RadioGroup';
 
 export default {
   components: {
     LabeledInput,
-    UnitInput,
     LabelValue,
     BadgeState,
     Banner,
+    RadioGroup,
   },
 
   props:      {
@@ -75,22 +75,36 @@ export default {
     isProvisioned() {
       return this.value?.blockDevice?.spec.fileSystem.provisioned;
     },
-  },
-  methods: {
-    update() {
-      this.$emit('input', this.value);
+
+    forceFormattedDisabled() {
+      const lastFormattedAt = this.value?.blockDevice?.status?.deviceStatus?.fileSystem?.lastFormattedAt;
+      const fileSystem = this.value?.blockDevice?.status?.deviceStatus?.fileSystem;
+      const partitioned = this.value?.blockDevice?.status?.deviceStatus?.partitioned;
+
+      if (lastFormattedAt || fileSystem || partitioned) {
+        return true;
+      } else if (!fileSystem && !partitioned) {
+        return true;
+      } else {
+        return !this.canEditPath;
+      }
     },
 
-    canEditPath(value) {
+    canEditPath() {
       if (this.mountedMessage) {
         return true;
       }
 
-      if (value.isNew && !value.originPath) {
+      if (this.value.isNew && !this.value.originPath) {
         return true;
       }
 
       return false;
+    },
+  },
+  methods: {
+    update() {
+      this.$emit('input', this.value);
     },
   },
 };
@@ -156,20 +170,22 @@ export default {
         <LabeledInput
           v-model="value.path"
           :label="t('harvester.host.disk.path.label')"
-          :disabled="!canEditPath(value)"
+          :disabled="!canEditPath"
           required
         />
       </div>
     </div>
-    <div v-if="false" class="row mt-10">
+    <div v-if="value.isNew" class="row mt-10">
       <div class="col span-6">
-        <UnitInput
-          v-model="value.storageReserved"
-          v-int-number
-          suffix="GiB"
-          label-key="harvester.host.disk.storageReserved.label"
+        <RadioGroup
+          v-model="value.forceFormatted"
           :mode="mode"
-          :disabled="true"
+          name="forceFormatted"
+          label-key="harvester.host.disk.forceFormatted.label"
+          :labels="[t('generic.no'),t('generic.yes')]"
+          :options="[false, true]"
+          :disabled="forceFormattedDisabled"
+          tooltip-key="harvester.host.disk.forceFormatted.toolTip"
         />
       </div>
     </div>

--- a/edit/harvesterhci.io.host/index.vue
+++ b/edit/harvesterhci.io.host/index.vue
@@ -16,11 +16,14 @@ import { HCI, LONGHORN } from '@/config/types';
 import { allHash } from '@/utils/promise';
 import { formatSi } from '@/utils/units';
 import { findBy, uniq } from '@/utils/array';
-import { matchesSomeRegex } from '@/utils/string';
+import { matchesSomeRegex, randomStr } from '@/utils/string';
 import { clone } from '@/utils/object';
 import { exceptionToErrorsArray } from '@/utils/error';
 import KeyValue from '@/components/form/KeyValue';
+import { sortBy } from '@/utils/sort';
 import HarvesterDisk from './HarvesterDisk';
+
+const LONGHORN_SYSTEM = 'longhorn-system';
 
 export default {
   name:       'HarvesterEditNode',
@@ -73,12 +76,13 @@ export default {
     })
       .map((d) => {
         return {
-          isNew:       true,
-          name:        d?.metadata?.name,
-          originPath:  d?.spec?.fileSystem?.mountPoint,
-          path:        d?.spec?.fileSystem?.mountPoint,
-          blockDevice: d,
-          displayName: d?.spec?.devPath,
+          isNew:          true,
+          name:           d?.metadata?.name,
+          originPath:     d?.spec?.fileSystem?.mountPoint,
+          path:           d?.spec?.fileSystem?.mountPoint,
+          blockDevice:    d,
+          displayName:    d?.spec?.devPath,
+          forceFormatted: d?.spec?.fileSystem?.forceFormatted || false,
         };
       });
 
@@ -124,7 +128,7 @@ export default {
       const inStore = this.$store.getters['currentProduct'].inStore;
       const blockDevices = this.$store.getters[`${ inStore }/all`](HCI.BLOCK_DEVICE);
 
-      return blockDevices
+      const out = blockDevices
         .filter((d) => {
           const addedToNodeCondition = findBy(d?.status?.conditions || [], 'type', 'AddedToNode');
           const isAdded = findBy(this.newDisks, 'name', d.metadata.name);
@@ -143,12 +147,19 @@ export default {
           }
         })
         .map((d) => {
+          const devPath = d.spec?.devPath;
+          const deviceType = d.status?.deviceStatus?.details?.deviceType;
+          const sizeBytes = d.status?.deviceStatus?.capacity?.sizeBytes;
+          const size = formatSi(sizeBytes, { increment: 1024 });
+
           return {
-            label:  d.spec?.devPath,
+            label:  `${ devPath } (Type: ${ deviceType }, Size: ${ size })`,
             value:  d.id,
             action: this.addDisk,
           };
         });
+
+      return sortBy(out, 'label');
     },
     removedDisks() {
       const out = this.disks.filter((d) => {
@@ -159,7 +170,7 @@ export default {
     },
     longhornDisks() {
       const inStore = this.$store.getters['currentProduct'].inStore;
-      const longhornNode = this.$store.getters[`${ inStore }/byId`](LONGHORN.NODES, `longhorn-system/${ this.value.id }`);
+      const longhornNode = this.$store.getters[`${ inStore }/byId`](LONGHORN.NODES, `${ LONGHORN_SYSTEM }/${ this.value.id }`);
       const diskStatus = longhornNode?.status?.diskStatus || {};
       const diskSpec = longhornNode.spec?.disks || {};
 
@@ -172,7 +183,7 @@ export default {
       };
 
       const longhornDisks = Object.keys(diskStatus).map((key) => {
-        const blockDevice = this.$store.getters[`${ inStore }/byId`](HCI.BLOCK_DEVICE, `longhorn-system/${ key }`);
+        const blockDevice = this.$store.getters[`${ inStore }/byId`](HCI.BLOCK_DEVICE, `${ LONGHORN_SYSTEM }/${ key }`);
 
         return {
           ...diskStatus[key],
@@ -185,6 +196,7 @@ export default {
           storageScheduled: formatSi(diskStatus[key]?.storageScheduled, formatOptions),
           blockDevice,
           displayName:      blockDevice?.spec?.devPath || key,
+          forceFormatted:   blockDevice?.spec?.fileSystem?.forceFormatted || false,
         };
       });
 
@@ -226,10 +238,19 @@ export default {
 
       const inStore = this.$store.getters['currentProduct'].inStore;
       const disk = this.$store.getters[`${ inStore }/byId`](HCI.BLOCK_DEVICE, id);
+      const mountPoint = disk?.spec?.fileSystem?.mountPoint;
+
+      let forceFormatted;
+
+      if (disk?.status?.deviceStatus?.fileSystem?.type) {
+        forceFormatted = false;
+      } else {
+        forceFormatted = !disk?.status?.deviceStatus?.partitioned;
+      }
 
       this.newDisks.push({
         name:              disk?.metadata?.name,
-        path:              disk?.spec?.fileSystem?.mountPoint,
+        path:              mountPoint || `/var/lib/harvester/extra-disks/${ randomStr(11) }`,
         allowScheduling:   false,
         evictionRequested: false,
         storageReserved:   0,
@@ -237,6 +258,7 @@ export default {
         originPath:        disk?.spec?.fileSystem?.mountPoint,
         blockDevice:       disk,
         displayName:       disk?.spec?.devPath,
+        forceFormatted,
       });
     },
     async saveDisk() {
@@ -264,16 +286,17 @@ export default {
 
       try {
         await Promise.all(addDisks.map((d) => {
-          const blockDevice = this.$store.getters[`${ inStore }/byId`](HCI.BLOCK_DEVICE, `longhorn-system/${ d.name }`);
+          const blockDevice = this.$store.getters[`${ inStore }/byId`](HCI.BLOCK_DEVICE, `${ LONGHORN_SYSTEM }/${ d.name }`);
 
           blockDevice.spec.fileSystem.provisioned = true;
           blockDevice.spec.fileSystem.mountPoint = d.path;
+          blockDevice.spec.fileSystem.forceFormatted = d.forceFormatted;
 
           return blockDevice.save();
         }));
 
         await Promise.all(removeDisks.map((d) => {
-          const blockDevice = this.$store.getters[`${ inStore }/byId`](HCI.BLOCK_DEVICE, `longhorn-system/${ d.name }`);
+          const blockDevice = this.$store.getters[`${ inStore }/byId`](HCI.BLOCK_DEVICE, `${ LONGHORN_SYSTEM }/${ d.name }`);
 
           blockDevice.spec.fileSystem.provisioned = false;
           blockDevice.spec.fileSystem.mountPoint = this.dismountBlockDevices[blockDevice.id];


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/1240
https://github.com/harvester/harvester/issues/1237

- Add `spec.fileSystem.forceFormatted`, If `status.deviceStatus.fileSystem.lastFormattedAt` exsits or path can not edit, disabel selection.
- If a disk has not yet been mounted and did not have a mount path, generate a unique random path with prefix /var/lib/harvester/extra-disks/ and pre-fill it. E.g. /var/lib/harvester/extra-disks/deadbeef123

![image](https://user-images.githubusercontent.com/18737885/134310288-b31a2c91-6531-48a7-9dd9-53f24b678dae.png)
