### PR TITLE
HARVESTER:fix:Add notification after user modified the host configs

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -5013,8 +5013,13 @@ harvester:
       forceFormatted:
         label: Force Formatted
         toolTip: Force formatted will cleanup disk data, make sure you backup all available data to prevent data loss.
+        yes: Yes (Ext4 File System)
       description:
         label: Description
+      lastFormattedAt:
+        info: The disk has already been force-formatted
+      notification:
+        success: 'Update host "{name}" configurations successfully.'
 
   virtualizationManagement:
     manage: Manage

--- a/assets/translations/zh-hans.yaml
+++ b/assets/translations/zh-hans.yaml
@@ -3973,8 +3973,13 @@ harvester:
       forceFormatted:
         label: 格式化
         toolTip: 格式化将会清除磁盘数据, 请确保对数据进行备份以免丢失.
+        yes: 是 (Ext4文件系统)
       description:
         label: 描述
+      lastFormattedAt:
+        info: 当前磁盘已完成格式化
+      notification:
+        success: '已更新主机"{name}"配置'
 
   virtualizationManagement:
     manage: 管理

--- a/edit/harvesterhci.io.host/HarvesterDisk.vue
+++ b/edit/harvesterhci.io.host/HarvesterDisk.vue
@@ -78,7 +78,7 @@ export default {
 
     forceFormattedDisabled() {
       const lastFormattedAt = this.value?.blockDevice?.status?.deviceStatus?.fileSystem?.lastFormattedAt;
-      const fileSystem = this.value?.blockDevice?.status?.deviceStatus?.fileSystem;
+      const fileSystem = this.value?.blockDevice?.status?.deviceStatus?.fileSystem.type;
       const partitioned = this.value?.blockDevice?.status?.deviceStatus?.partitioned;
 
       if (fileSystem) {
@@ -103,6 +103,10 @@ export default {
 
       return false;
     },
+
+    isFormatted() {
+      return !!this.value?.blockDevice?.status?.deviceStatus?.fileSystem?.lastFormattedAt;
+    },
   },
   methods: {
     update() {
@@ -119,6 +123,11 @@ export default {
       v-if="mountedMessage && isProvisioned"
       color="error"
       :label="mountedMessage"
+    />
+    <Banner
+      v-if="isFormatted"
+      color="info"
+      :label="t('harvester.host.disk.lastFormattedAt.info')"
     />
     <div v-if="!value.isNew">
       <div class="row">
@@ -184,7 +193,7 @@ export default {
           :mode="mode"
           name="forceFormatted"
           label-key="harvester.host.disk.forceFormatted.label"
-          :labels="[t('generic.no'),t('generic.yes')]"
+          :labels="[t('generic.no'),t('harvester.host.disk.forceFormatted.yes')]"
           :options="[false, true]"
           :disabled="forceFormattedDisabled"
           tooltip-key="harvester.host.disk.forceFormatted.toolTip"

--- a/edit/harvesterhci.io.host/index.vue
+++ b/edit/harvesterhci.io.host/index.vue
@@ -249,13 +249,11 @@ export default {
       const mountPoint = disk?.spec?.fileSystem?.mountPoint;
 
       let forceFormatted;
-      const deviceType = disk?.status?.deviceStatus?.details?.deviceType;
+      const systems = ['ext4', 'XFS'];
 
-      if (disk?.status?.deviceStatus?.fileSystem?.type) {
+      if (systems.includes(disk?.status?.deviceStatus?.fileSystem?.type)) {
         forceFormatted = false;
-      } else if (deviceType === 'part') {
-        forceFormatted = false;
-      } else if (deviceType === 'disk') {
+      } else {
         forceFormatted = !disk?.status?.deviceStatus?.partitioned;
       }
 
@@ -316,6 +314,11 @@ export default {
 
           return blockDevice.save();
         }));
+
+        this.$store.dispatch('growl/success', {
+          title:   this.t('harvester.notification.title.succeed'),
+          message: this.t('harvester.host.disk.notification.success', { name: this.value.metadata?.name || '' }),
+        }, { root: true });
       } catch (err) {
         return Promise.reject(exceptionToErrorsArray(err));
       }


### PR DESCRIPTION

- either block device or partition's status.deviceStatus.fileSystem.type  exist -> false, other must be true
    - fileSystem type must equal to ext4 or XFS (as longhorn only support those two types, otherwise it should be default to true of force-formatted
- Add notification after user modified the host configs https://github.com/harvester/harvester/issues/1284