### PR TITLE
HARVESTER: Hide capacity & disks & networks for member roles

### DIFF
--- a/detail/harvesterhci.io.host/HarvesterHostBasic.vue
+++ b/detail/harvesterhci.io.host/HarvesterHostBasic.vue
@@ -2,8 +2,8 @@
 import LabelValue from '@/components/LabelValue';
 import Banner from '@/components/Banner';
 import { formatSi, exponentNeeded, UNITS } from '@/utils/units';
-import { HCI } from '@/config/labels-annotations';
-import { LONGHORN } from '@/config/types';
+import { HCI as HCI_ANNOTATIONS } from '@/config/labels-annotations';
+import { LONGHORN, METRIC, HCI } from '@/config/types';
 import HarvesterCPUUsed from '@/components/formatter/HarvesterCPUUsed';
 import HarvesterMemoryUsed from '@/components/formatter/HarvesterMemoryUsed';
 import HarvesterStorageUsed from '@/components/formatter/HarvesterStorageUsed';
@@ -55,11 +55,11 @@ export default {
 
   computed: {
     customName() {
-      return this.value.metadata?.annotations?.[HCI.HOST_CUSTOM_NAME];
+      return this.value.metadata?.annotations?.[HCI_ANNOTATIONS.HOST_CUSTOM_NAME];
     },
 
     consoleUrl() {
-      const consoleUrl = this.value.metadata?.annotations?.[HCI.HOST_CONSOLE_URL];
+      const consoleUrl = this.value.metadata?.annotations?.[HCI_ANNOTATIONS.HOST_CONSOLE_URL];
       let value = consoleUrl;
 
       if (!consoleUrl) {
@@ -173,8 +173,8 @@ export default {
     },
 
     nodeRoleState() {
-      const isExistRoleStatus = this.value.metadata?.labels?.[HCI.NODE_ROLE_MASTER] !== undefined || this.value.metadata?.labels?.[HCI.NODE_ROLE_CONTROL_PLANE] !== undefined;
-      const promoteStatus = this.value.metadata?.annotations?.[HCI.PROMOTE_STATUS] || NONE;
+      const isExistRoleStatus = this.value.metadata?.labels?.[HCI_ANNOTATIONS.NODE_ROLE_MASTER] !== undefined || this.value.metadata?.labels?.[HCI_ANNOTATIONS.NODE_ROLE_CONTROL_PLANE] !== undefined;
+      const promoteStatus = this.value.metadata?.annotations?.[HCI_ANNOTATIONS.PROMOTE_STATUS] || NONE;
 
       if (!isExistRoleStatus && promoteStatus === COMPLETE) {
         return PROMOTE_RESTART;
@@ -195,7 +195,19 @@ export default {
 
     networkMessage() {
       return this.hostNetworkResource?.message;
-    }
+    },
+
+    hasMetricNodeSchema() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+
+      return !!this.$store.getters[`${ inStore }/schemaFor`](METRIC.NODE);
+    },
+
+    hasHostNetworksSchema() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+
+      return !!this.$store.getters[`${ inStore }/schemaFor`](HCI.NODE_NETWORK);
+    },
   },
 
   methods: {
@@ -261,44 +273,48 @@ export default {
       </div>
     </div>
 
-    <hr class="divider" />
-    <h3>{{ t('harvester.host.detail.title.network') }}</h3>
-    <Banner v-if="networkMessage" color="error">
-      {{ networkMessage }}
-    </Banner>
-    <div class="row mb-20">
-      <div class="col span-6">
-        <LabelValue :name="t('harvester.host.detail.networkType')" :value="networkType" />
-      </div>
+    <div v-if="hasHostNetworksSchema">
+      <hr class="divider" />
+      <h3>{{ t('harvester.host.detail.title.network') }}</h3>
+      <Banner v-if="networkMessage" color="error">
+        {{ networkMessage }}
+      </Banner>
+      <div class="row mb-20">
+        <div class="col span-6">
+          <LabelValue :name="t('harvester.host.detail.networkType')" :value="networkType" />
+        </div>
 
-      <div class="col span-6">
-        <LabelValue :name="t('harvester.host.detail.nic')" :value="nic" />
+        <div class="col span-6">
+          <LabelValue :name="t('harvester.host.detail.nic')" :value="nic" />
+        </div>
       </div>
     </div>
 
-    <hr class="divider" />
-    <h3>{{ t('harvester.host.tabs.monitor') }}</h3>
-    <div class="row mb-20">
-      <div class="col span-4">
-        <HarvesterCPUUsed
-          :row="value"
-          :resource-name="t('node.detail.glance.consumptionGauge.cpu')"
-          :show-used="true"
-        />
-      </div>
-      <div class="col span-4">
-        <HarvesterMemoryUsed
-          :row="value"
-          :resource-name="t('node.detail.glance.consumptionGauge.memory')"
-          :show-used="true"
-        />
-      </div>
-      <div class="col span-4">
-        <HarvesterStorageUsed
-          :row="value"
-          :resource-name="t('harvester.host.detail.storage')"
-          :show-reserved="true"
-        />
+    <div v-if="hasMetricNodeSchema">
+      <hr class="divider" />
+      <h3>{{ t('harvester.host.tabs.monitor') }}</h3>
+      <div class="row mb-20">
+        <div class="col span-4">
+          <HarvesterCPUUsed
+            :row="value"
+            :resource-name="t('node.detail.glance.consumptionGauge.cpu')"
+            :show-used="true"
+          />
+        </div>
+        <div class="col span-4">
+          <HarvesterMemoryUsed
+            :row="value"
+            :resource-name="t('node.detail.glance.consumptionGauge.memory')"
+            :show-used="true"
+          />
+        </div>
+        <div class="col span-4">
+          <HarvesterStorageUsed
+            :row="value"
+            :resource-name="t('harvester.host.detail.storage')"
+            :show-reserved="true"
+          />
+        </div>
       </div>
     </div>
 

--- a/edit/harvesterhci.io.host/index.vue
+++ b/edit/harvesterhci.io.host/index.vue
@@ -179,6 +179,19 @@ export default {
 
       return out.length > 0;
     },
+
+    hasHostNetworksSchema() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+
+      return !!this.$store.getters[`${ inStore }/schemaFor`](HCI.NODE_NETWORK);
+    },
+
+    hasBlockDevicesSchema() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+
+      return !!this.$store.getters[`${ inStore }/schemaFor`](HCI.BLOCK_DEVICE);
+    },
+
   },
   watch: {
     customName(neu) {
@@ -418,7 +431,7 @@ export default {
           :mode="mode"
         />
       </Tab>
-      <Tab name="network" :weight="90" :label="t('harvester.host.tabs.network')">
+      <Tab v-if="hasHostNetworksSchema" name="network" :weight="90" :label="t('harvester.host.tabs.network')">
         <InfoBox class="wrapper">
           <div class="row warpper">
             <div class="col span-6">
@@ -453,6 +466,7 @@ export default {
         </InfoBox>
       </Tab>
       <Tab
+        v-if="hasBlockDevicesSchema"
         name="disk"
         :weight="80"
         :label="t('harvester.host.tabs.disk')"

--- a/list/harvesterhci.io.dashboard/index.vue
+++ b/list/harvesterhci.io.dashboard/index.vue
@@ -187,7 +187,7 @@ export default {
             const statistics = clusterCounts[resource.type] || {};
 
             for (let i = 0; i < resource.spoofed.filterNamespace.length; i++) {
-              const nsStatistics = statistics?.namespaces[resource.spoofed.filterNamespace[i]] || {};
+              const nsStatistics = statistics?.namespaces?.[resource.spoofed.filterNamespace[i]] || {};
 
               if (nsStatistics.count) {
                 out[resource.type]['useful'] -= nsStatistics.count;
@@ -448,6 +448,12 @@ export default {
     ramUsed() {
       return createMemoryValues(this.memorysTotal, this.metricAggregations?.memory);
     },
+
+    hasMetricNodeSchema() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+
+      return !!this.$store.getters[`${ inStore }/schemaFor`](METRIC.NODE);
+    },
   },
 
   methods: {
@@ -561,7 +567,7 @@ export default {
       />
     </div>
 
-    <template v-if="nodes.length">
+    <template v-if="nodes.length && hasMetricNodeSchema">
       <h3 class="mt-40">
         {{ t('clusterIndexPage.sections.capacity.label') }}
       </h3>

--- a/list/harvesterhci.io.host/index.vue
+++ b/list/harvesterhci.io.host/index.vue
@@ -33,8 +33,6 @@ export default {
   async fetch() {
     const _hash = {
       nodes:         this.$store.dispatch('harvester/findAll', { type: NODE }),
-      longhornNodes: this.$store.dispatch('harvester/findAll', { type: LONGHORN.NODES }),
-      blockDevices:  this.$store.dispatch('harvester/findAll', { type: HCI.BLOCK_DEVICE }),
       pods:          this.$store.dispatch('harvester/findAll', { type: POD }),
     };
 
@@ -43,6 +41,15 @@ export default {
     } else {
       this.hasMetricSchema = false;
     }
+
+    if (this.$store.getters['harvester/schemaFor'](LONGHORN.NODES)) {
+      _hash.longhornNodes = this.$store.dispatch('harvester/findAll', { type: LONGHORN.NODES });
+    }
+
+    if (this.$store.getters['harvester/schemaFor'](HCI.BLOCK_DEVICE)) {
+      _hash.blockDevices = this.$store.dispatch('harvester/findAll', { type: HCI.BLOCK_DEVICE });
+    }
+
     const hash = await allHash(_hash);
 
     this.rows = hash.nodes;


### PR DESCRIPTION
## Linked Issues

- [https://github.com/harvester/harvester/issues/1841](https://github.com/harvester/harvester/issues/1841)

#### Hide
- HCI.NODE_NETWORK _network tab on Host page_
- HCI.BLOCK_DEVICE _disk tab on Host page_
- METRIC.NODE _capacity section on Dashboard page_