### PR TITLE
HARVESTSER: Support add a disk insteadof a partition

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -5283,10 +5283,12 @@ harvester:
       description:
         label: Description
       lastFormattedAt:
-        info: The disk has already been force-formatted
+        info: The disk has already been force-formatted.
       notification:
         success: 'Update host "{name}" configurations successfully.'
       error: Host has unready or unschedulable disks.
+      fileSystem:
+        info: Current file system is {system}, You can format it manually.
 
   virtualizationManagement:
     manage: Manage

--- a/edit/harvesterhci.io.host/HarvesterDisk.vue
+++ b/edit/harvesterhci.io.host/HarvesterDisk.vue
@@ -81,15 +81,14 @@ export default {
     forceFormattedDisabled() {
       const lastFormattedAt = this.value?.blockDevice?.status?.deviceStatus?.fileSystem?.LastFormattedAt;
       const fileSystem = this.value?.blockDevice?.status?.deviceStatus?.fileSystem.type;
-      const partitioned = this.value?.blockDevice?.status?.deviceStatus?.partitioned;
 
       const systems = ['ext4', 'XFS'];
 
-      if (systems.includes(fileSystem)) {
-        return false;
-      } else if (lastFormattedAt) {
+      if (lastFormattedAt) {
         return true;
-      } else if (!fileSystem && !partitioned) {
+      } else if (systems.includes(fileSystem)) {
+        return false;
+      } if (!fileSystem) {
         return true;
       } else {
         return !this.canEditPath;
@@ -110,6 +109,18 @@ export default {
 
     isFormatted() {
       return !!this.value?.blockDevice?.status?.deviceStatus?.fileSystem?.LastFormattedAt;
+    },
+
+    formattedBannerLabel() {
+      const system = this.value?.blockDevice?.status?.deviceStatus?.fileSystem?.type;
+
+      const label = this.t('harvester.host.disk.lastFormattedAt.info');
+
+      if (system) {
+        return `${ label } ${ this.t('harvester.host.disk.fileSystem.info', { system }) }`;
+      } else {
+        return label;
+      }
     },
 
     provisionPhase() {
@@ -135,7 +146,7 @@ export default {
     <Banner
       v-if="isFormatted"
       color="info"
-      :label="t('harvester.host.disk.lastFormattedAt.info')"
+      :label="formattedBannerLabel"
     />
     <div v-if="!value.isNew">
       <div class="row">

--- a/edit/harvesterhci.io.host/index.vue
+++ b/edit/harvesterhci.io.host/index.vue
@@ -233,14 +233,15 @@ export default {
       const inStore = this.$store.getters['currentProduct'].inStore;
       const disk = this.$store.getters[`${ inStore }/byId`](HCI.BLOCK_DEVICE, id);
       const mountPoint = disk?.spec?.fileSystem?.mountPoint;
+      const lastFormattedAt = disk?.status?.deviceStatus?.fileSystem?.LastFormattedAt;
 
-      let forceFormatted;
+      let forceFormatted = true;
       const systems = ['ext4', 'XFS'];
 
-      if (systems.includes(disk?.status?.deviceStatus?.fileSystem?.type)) {
+      if (lastFormattedAt) {
         forceFormatted = false;
-      } else {
-        forceFormatted = !disk?.status?.deviceStatus?.partitioned;
+      } else if (systems.includes(disk?.status?.deviceStatus?.fileSystem?.type)) {
+        forceFormatted = false;
       }
 
       const name = disk?.metadata?.name;
@@ -355,10 +356,9 @@ export default {
           const isAdded = findBy(this.newDisks, 'name', d.metadata.name);
           const isRemoved = findBy(this.removedDisks, 'name', d.metadata.name);
 
-          const parentDevice = d.status?.deviceStatus?.parentDevice;
-          const isParentSelected = this.newDisks.find(d => d?.blockDevice?.spec?.devPath === parentDevice);
+          const deviceType = d.status?.deviceStatus?.details?.deviceType;
 
-          if (parentDevice && isParentSelected) {
+          if (deviceType !== 'disk') {
             return false;
           }
 


### PR DESCRIPTION
**Link issue**
- https://github.com/harvester/harvester/issues/1839

**Change**
According to [issue comment](https://github.com/harvester/harvester/issues/1839#issuecomment-1049516424)

- Only show block device which type is disk
- When the disk is formatted and the system exists, the format option is disabled, and show a banner to info the user what the system is and can be formatted manually.



**Verify Steps**

A disk without format: 
1. Add a new disk
2. Check formate option. Option should be force format.


A disk is formated and the filesystem exits
1. Add a new disk
2. remove the disk
3. Add the disk again
4. Check the banner

A disk is formated manually
1. Format disk. e.g. `mkfs.ext4 /dev/nvme0n1`
2. Add the disk
3. Check the format option


**Additional Context**

![image](https://user-images.githubusercontent.com/18737885/156147235-c8958d2a-2030-437b-b97d-ce7157d1c7ef.png)

