### PR TITLE
HARVESTER: VM created by VM Template will use new secret

### DIFF
--- a/edit/kubevirt.io.virtualmachine/index.vue
+++ b/edit/kubevirt.io.virtualmachine/index.vue
@@ -174,11 +174,16 @@ export default {
         }
         const versions = await this.$store.dispatch('harvester/findAll', { type: HCI.VM_VERSION });
         const curVersion = versions.find( V => V.id === id);
+        const cloneVersionVM = clone(curVersion.spec.vm);
 
-        this.getInitConfig({ value: curVersion.spec.vm });
+        delete cloneVersionVM.spec?.template?.spec?.accessCredentials;
+        delete cloneVersionVM.spec?.template?.metadata?.annotations?.[HCI_ANNOTATIONS.DYNAMIC_SSHKEYS_NAMES];
+        delete cloneVersionVM.spec?.template?.metadata?.annotations?.[HCI_ANNOTATIONS.DYNAMIC_SSHKEYS_USERS];
+
+        this.getInitConfig({ value: cloneVersionVM });
         this.$set(this, 'hasCreateVolumes', []); // When using the template, all volume names need to be newly created
 
-        const claimTemplate = this.getVolumeClaimTemplates(curVersion.spec.vm);
+        const claimTemplate = this.getVolumeClaimTemplates(cloneVersionVM);
 
         this.value.metadata.annotations[HCI_ANNOTATIONS.VOLUME_CLAIM_TEMPLATE] = JSON.stringify(claimTemplate);
       }


### PR DESCRIPTION
## Linked Issues

- [https://github.com/harvester/harvester/issues/1989](https://github.com/harvester/harvester/issues/1989)

## Test Steps
1. Create VM `A`
2. Add Access Credentials to VM `A`, use credentials could access VM `A`.
3. Generate VM Template from VM `A`.
4. Lanuch new VM `B` from the VM Template, VM B should not have the credentials.
_we intend to implement the enhancement in 1.0.2 that VMs created by VM templates include credentials_
5. Clone VM `A`, should clone successfully and credentials should be saved in new Secret.
6. Go to VM Create Page
7. Use template to create VM `C`, should create successfully.
8. Add Access Credentials to `B`, should add successfully.
9. Add Access Credentials to `C`, should add successfully.
10. Remove Access Credentials of `B`, should remove successfully.
11. Remove Access Credentials of `C`, should remove successfully.