### PR TITLE
HARVESTER: remove sriov type

### DIFF
--- a/edit/kubevirt.io.virtualmachine/VirtualMachineNetwork/base.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineNetwork/base.vue
@@ -116,10 +116,13 @@ export default {
       const other = [{
         label: 'bridge',
         value: 'bridge'
-      }, {
-        label: 'sriov',
-        value: 'sriov'
-      }];
+      }
+      // Temporarily Remove
+      // , {
+      //   label: 'sriov',
+      //   value: 'sriov'
+      // }
+      ];
 
       return this.isMasquerade ? masquerade : other;
     }


### PR DESCRIPTION
Hardware part is not supported now, related tracking issue https://github.com/harvester/harvester/issues/992，

After discussion, the frontend temporarily removed the `sriov` configuration
