### PR TITLE
HARVESTER: hide view config for backup

### DIFF
--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -231,7 +231,7 @@ export default {
         });
       }
 
-      if ( this.hasEdit ) {
+      if ( this.hasEdit && this.parent?.showConfigView !== false) {
         out.push({
           labelKey: 'resourceDetail.masthead.config',
           value:    'config',

--- a/config/product/harvester.js
+++ b/config/product/harvester.js
@@ -215,7 +215,7 @@ export function init(store) {
     exact: false,
   });
 
-  configureType(HCI.BACKUP, { showListMasthead: false });
+  configureType(HCI.BACKUP, { showListMasthead: false, showConfigView: false });
   virtualType({
     labelKey:   'harvester.backup.label',
     name:       HCI.BACKUP,

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -90,6 +90,8 @@
 //                               isRemovable: true,  -- Ditto, for remove/delete
 //                               showState: true,  -- If false, hide state in columns and masthead
 //                               showAge: true,    -- If false, hide age in columns and masthead
+//                               showConfigView: true -- If false, hide masthead config button in view mode
+//                               showListMasthead: true, -- If false, hide masthead in list view
 //                               canYaml: true,
 //                               resource: undefined       -- Use this resource in ResourceDetails instead
 //                               resourceDetail: undefined -- Use this resource specifically for ResourceDetail's detail component


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/1978 
This PR hides the 'config' view for backups. The ResourceDetail Masthead renders the 'Detail' and 'Config' buttons when the resource has components defined in `/view` and `/edit` respectively: this is not appropriate for `harvesterhci.io.virtualmachinebackup` because the `/edit/harvesterhci.io.virtualmachinebackup` component is for the creation of `harvesterhci.io.virtualmachinerestore` resources. Initially I thought to restructure the backup/restore components to align with the assumptions made in ResourceDetail and type-map but it required _many_ changes just to hide a button so I think this approach of making type-map and ResourceDetail more configurable is better.
![Screen Shot 2022-04-18 at 4 50 47 PM](https://user-images.githubusercontent.com/42977925/163894358-2247f8ec-3331-4a4c-873a-b1266b390b80.png)

