### PR TITLE
HARVESTER: VM console only disabled when VM is stopped

### DIFF
--- a/components/VMConsoleBar.vue
+++ b/components/VMConsoleBar.vue
@@ -1,6 +1,7 @@
 <script>
 import ButtonDropdown from '@/components/ButtonDropdown';
 import { mapGetters } from 'vuex';
+import { OFF } from '@/models/harvester/kubevirt.io.virtualmachine';
 
 export default {
   name: 'VMConsoleBar',
@@ -20,8 +21,8 @@ export default {
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
 
-    isRunning() {
-      return !!this.resource.isRunning;
+    isOff() {
+      return this.resource.stateDisplay === OFF;
     },
 
     options() {
@@ -66,8 +67,8 @@ export default {
 <template>
   <div class="overview-web-console">
     <ButtonDropdown
-      :disabled="!isRunning"
-      :no-drop="!isRunning"
+      :disabled="isOff"
+      :no-drop="isOff"
       button-label="Console"
       :dropdown-options="options"
       size="sm"


### PR DESCRIPTION
## Linked Issues

- [https://github.com/harvester/harvester/issues/1938](https://github.com/harvester/harvester/issues/1938)

## Verify Steps
1. Create VM A
2. The console bar of VM A would only be disabled when VM A is stopped.
3. open VNC console / Serial console on any phase of VM, UI should work fine.