### PR TITLE
HARVESTER: fix project/ns filter on page reload

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -825,7 +825,16 @@ export const actions = {
       hash.upgrades = dispatch('harvester/findAll', { type: HCI.UPGRADE });
     }
 
-    await allHash(hash);
+    const res = await allHash(hash);
+
+    await dispatch('cleanNamespaces');
+
+    const filters = getters['prefs/get'](NAMESPACE_FILTERS)?.[id];
+
+    commit('updateNamespaces', {
+      filters: filters || [ALL_USER],
+      all:     res.virtualNamespaces
+    });
 
     commit('clusterChanged', true);
 


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/2001

On initial load in cluster explorer, project/namespace filtering is loaded from user preferences in `loadCluster` [here](https://github.com/harvester/dashboard/blob/master/store/index.js#L708-L715) - `loadVirtual` was missing this. 