### PR TITLE
Fix multiple cluster namespace filter

### DIFF
--- a/shell/list/namespace.vue
+++ b/shell/list/namespace.vue
@@ -22,7 +22,9 @@ export default {
     filterRow() {
       if (this.isVirtualCluster) {
         return this.rows.filter( (N) => {
-          return !N.isSystem && !N.isFleetManaged;
+          const isSettingSystemNamespace = this.$store.getters['systemNamespaces'].includes(N.metadata.name);
+
+          return !N.isSystem && !N.isFleetManaged && !isSettingSystemNamespace;
         });
       } else {
         return this.rows;

--- a/shell/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/shell/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -127,7 +127,10 @@ export default {
       const isVirtualProduct = this.$store.getters['currentProduct'].name === HARVESTER;
 
       return this.namespaces.filter((namespace) => {
-        return isVirtualCluster && isVirtualProduct ? (!namespace.isSystem && !namespace.isObscure) : !namespace.isObscure;
+        const isSettingSystemNamespace = this.$store.getters['systemNamespaces'].includes(namespace.metadata.name);
+        const systemNS = namespace.isSystem || namespace.isFleetManaged || isSettingSystemNamespace;
+
+        return isVirtualCluster && isVirtualProduct ? (!systemNS && !namespace.isObscure) : !namespace.isObscure;
       });
     },
 

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -863,6 +863,20 @@ export const actions = {
       virtualBase = `/v1/harvester`;
     }
 
+    if (id !== 'local') { // multi-cluster
+      const systemNamespaces = await dispatch('management/find', {
+        type: MANAGEMENT.SETTING,
+        id:   SETTING.SYSTEM_NAMESPACES,
+        opt:  { url: `${ virtualBase }/${ MANAGEMENT.SETTING }s/${ SETTING.SYSTEM_NAMESPACES }`, force: true }
+      });
+
+      if (systemNamespaces) {
+        const namespace = (systemNamespaces.value || systemNamespaces.default)?.split(',');
+
+        commit('setSystemNamespaces', namespace);
+      }
+    }
+
     if ( !cluster ) {
       commit('clusterId', null);
       commit('harvester/applyConfig', { baseUrl: null });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
test step:
1. In a single cluster, the data displayed on the namespace page should be consistent with the namespace filter data on all edit pages
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/24985926/172329918-ee3f124f-f8c3-4066-945d-c4b0217605a1.png">
<img width="669" alt="image" src="https://user-images.githubusercontent.com/24985926/172329998-e808cf9c-4caf-48bb-9dd6-4222ca6256ff.png">
<img width="378" alt="image" src="https://user-images.githubusercontent.com/24985926/172330025-98e51c83-57b4-44e7-a956-567fd0eed592.png">

2. In multiple clusters, the data displayed on the 'Projects/Namespaces' page should also be consistent with the namespace data used elsewhere.  (Note that the projects/Namespace page in the development environment shows all namespaces)
<img width="1675" alt="image" src="https://user-images.githubusercontent.com/24985926/172331845-793a1d24-e7cc-4e73-93d7-41f06d92a036.png">


Fixes #
- https://github.com/harvester/harvester/issues/2116
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->