### PR TITLE
websocket disconnect growl

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2012,6 +2012,12 @@ graphOptions:
   refresh: Refresh
   range: Range
 
+growl:
+  clearAll: Clear All Notifications
+  disconnected: 
+    message: "The connection to {url} closed unexpectedly {time}. Retrying..."
+    title: Websocket Disconnected 
+
 hpa:
   detail:
     currentMetrics:

--- a/shell/components/GrowlManager.vue
+++ b/shell/components/GrowlManager.vue
@@ -96,7 +96,7 @@ export default {
     </div>
     <div v-if="stack.length > 1" class="text-right mr-10 mt-10">
       <button type="button" class="btn btn-sm role-primary" @click="closeAll">
-        Clear All Notifications
+        {{ t('growl.clearAll') }}
       </button>
     </div>
   </div>
@@ -142,6 +142,8 @@ export default {
     .growl-text {
       flex-basis: 90%;
       padding: 10px 10px 10px 0;
+      word-break: break-word;
+      white-space: normal;
 
       > div {
         font-size: 16px;

--- a/shell/models/harvester/node.js
+++ b/shell/models/harvester/node.js
@@ -101,7 +101,7 @@ export default class HciNode extends SteveModel {
     }
 
     if (this.isMaintenance) {
-      return 'Maintenance mode';
+      return 'Maintenance';
     }
 
     if (this.isCordoned ) {

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -5,9 +5,13 @@ import Socket, {
   EVENT_DISCONNECTED,
   EVENT_MESSAGE,
   //  EVENT_FRAME_TIMEOUT,
-  EVENT_CONNECT_ERROR
+  EVENT_CONNECT_ERROR,
+  EVENT_DISCONNECT_ERROR
 } from '@shell/utils/socket';
 import { normalizeType } from '@shell/plugins/dashboard-store/normalize';
+import day from 'dayjs';
+import { DATE_FORMAT, TIME_FORMAT } from '@shell/store/prefs';
+import { escapeHtml } from '@shell/utils/string';
 
 export const NO_WATCH = 'NO_WATCH';
 export const NO_SCHEMA = 'NO_SCHEMA';
@@ -108,7 +112,6 @@ export const actions = {
       socket = new Socket(`${ state.config.baseUrl }/subscribe`);
 
       commit('setSocket', socket);
-
       socket.addEventListener(EVENT_CONNECTED, (e) => {
         dispatch('opened', e);
       });
@@ -118,7 +121,11 @@ export const actions = {
       });
 
       socket.addEventListener(EVENT_CONNECT_ERROR, (e) => {
-        dispatch('error', e.detail);
+        dispatch('error', e );
+      });
+
+      socket.addEventListener(EVENT_DISCONNECT_ERROR, (e) => {
+        dispatch('error', e );
       });
 
       socket.addEventListener(EVENT_MESSAGE, (e) => {
@@ -338,7 +345,7 @@ export const actions = {
   },
 
   async opened({
-    commit, dispatch, state, getters
+    commit, dispatch, state, getters, rootGetters
   }, event) {
     state.debugSocket && console.info(`WebSocket Opened [${ getters.storeName }]`); // eslint-disable-line no-console
 
@@ -364,6 +371,12 @@ export const actions = {
 
     if ( socket.hasReconnected ) {
       await dispatch('reconnectWatches');
+      // Check for disconnect notifications and clear them
+      const growlErr = rootGetters['growl/find']({ key: 'url', val: this.$socket.url });
+
+      if (growlErr) {
+        dispatch('growl/remove', growlErr.id, { root: true });
+      }
     }
 
     // Try resending any frames that were attempted to be sent while the socket was down, once.
@@ -381,10 +394,28 @@ export const actions = {
     state.queueTimer = null;
   },
 
-  error({ getters, state }, event) {
-    console.error(`WebSocket Error [${ getters.storeName }]`, event); // eslint-disable-line no-console
+  error({
+    getters, state, dispatch, rootGetters
+  }, e) {
     clearTimeout(state.queueTimer);
     state.queueTimer = null;
+    if (e.type === EVENT_DISCONNECT_ERROR) {
+      const dateFormat = escapeHtml( rootGetters['prefs/get'](DATE_FORMAT));
+      const timeFormat = escapeHtml( rootGetters['prefs/get'](TIME_FORMAT));
+      let time = e?.srcElement?.disconnectedAt || Date.now();
+
+      time = `${ day(time).format(`${ dateFormat } ${ timeFormat }`) }`;
+      const url = e?.srcElement?.url;
+
+      const t = rootGetters['i18n/t'];
+
+      dispatch('growl/error', {
+        title:   t('growl.disconnected.title'),
+        message: t('growl.disconnected.message', { url, time }, { raw: true }),
+        icon:    'error',
+        url
+      }, { root: true });
+    }
   },
 
   send({ state, commit }, obj) {

--- a/shell/store/growl.js
+++ b/shell/store/growl.js
@@ -10,6 +10,12 @@ export const state = function() {
   };
 };
 
+export const getters = {
+  find: state => ({ key, val }) => {
+    return findBy(state.stack, key, val);
+  }
+};
+
 export const mutations = {
   add(state, data) {
     state.stack.push({

--- a/shell/utils/socket.js
+++ b/shell/utils/socket.js
@@ -21,6 +21,7 @@ export const EVENT_DISCONNECTED = STATE_DISCONNECTED;
 export const EVENT_MESSAGE = 'message';
 export const EVENT_FRAME_TIMEOUT = 'frame_timeout';
 export const EVENT_CONNECT_ERROR = 'connect_error';
+export const EVENT_DISCONNECT_ERROR = 'disconnect_error';
 
 export default class Socket extends EventTarget {
   url;
@@ -254,7 +255,6 @@ export default class Socket extends EventTarget {
 
   _closed() {
     console.log(`Socket ${ this.closingId } closed`); // eslint-disable-line no-console
-
     this.closingId = 0;
     this.socket = null;
     clearTimeout(this.reconnectTimer);
@@ -287,6 +287,11 @@ export default class Socket extends EventTarget {
       this.dispatchEvent(e);
       warningShown = true;
     } else if ( this.autoReconnect ) {
+      if (this.tries === 0) {
+        const e = new CustomEvent(EVENT_DISCONNECT_ERROR);
+
+        this.dispatchEvent(e);
+      }
       this.state = STATE_RECONNECTING;
       this.tries++;
       const delay = Math.max(1000, Math.min(1000 * this.tries, 30000));


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
 https://github.com/harvester/harvester/issues/2186
This PR adds growl notifications when a websocket disconnects and attempts to reconnect. Disconnect growls are sent when an `onclose` websocket event is received and the associated socket wrapper is configured to automatically attempt to reconnect. When a socket reconnects the notification is closed.

### Screenshot/Video

https://user-images.githubusercontent.com/42977925/175362950-23fe3ac6-8a89-42be-b6a3-0e959a22679a.mov


