### PR TITLE
Harvester: Image volume can be empty in VM template

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5870,6 +5870,10 @@ harvester:
       basics: Basics
     nameNsDescription:
       name: Template Name
+    tips:
+      notExistImage:
+        title: Image {name} does not exist!
+        message: Please select a new Image.
 
   upgradePage:
     upgradeApp: Upgrade Software

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -5793,6 +5793,10 @@ harvester:
       basics: 基本信息
     nameNsDescription:
       name: 模板名称
+    tips:
+      notExistImage:
+        title: 镜像 {name} 不存在!
+        message: 请重新选择镜像
 
   upgradePage:
     upgradeApp: 升级软件

--- a/shell/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/index.vue
+++ b/shell/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/index.vue
@@ -328,7 +328,6 @@ export default {
       <button
         type="button"
         class="btn btn-sm bg-primary mb-10"
-        :disabled="rows.length === 0"
         @click="addVolume(SOURCE_TYPE.CONTAINER)"
       >
         {{ t('harvester.virtualMachine.volume.addContainer') }}

--- a/shell/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/shell/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -1,4 +1,5 @@
 <script>
+import { findBy } from '@shell/utils/array';
 import UnitInput from '@shell/components/form/UnitInput';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
@@ -106,6 +107,15 @@ export default {
         this.update();
       }
     },
+
+    'value.image'(neu) {
+      this.checkImageExists(neu);
+    },
+
+    imagesOption() {
+      this.checkImageExists(this.value.image);
+    },
+
     pvcsResource: {
       handler(pvc) {
         if (pvc?.spec?.resources?.requests?.storage && this.isVirtualType) {
@@ -150,6 +160,17 @@ export default {
     onOpen() {
       this.images = this.$store.getters['harvester/all'](HCI.IMAGE);
     },
+
+    checkImageExists(imageId) {
+      if (!!imageId && this.imagesOption.length > 0 && !findBy(this.imagesOption, 'value', imageId)) {
+        this.$store.dispatch('growl/error', {
+          title:   this.$store.getters['i18n/t']('harvester.vmTemplate.tips.notExistImage.title', { name: imageId }),
+          message: this.$store.getters['i18n/t']('harvester.vmTemplate.tips.notExistImage.message')
+        }, { root: true });
+
+        this.$set(this.value, 'image', '');
+      }
+    }
   }
 };
 </script>

--- a/shell/mixins/harvester-vm/index.js
+++ b/shell/mixins/harvester-vm/index.js
@@ -796,6 +796,8 @@ export default {
         if (image) {
           out.spec.storageClassName = `longhorn-${ image.metadata.name }`;
           out.metadata.annotations = { [HCI_ANNOTATIONS.IMAGE_ID]: image.id };
+        } else if (this.resource === HCI.VM_VERSION) {
+          out.metadata.annotations = { [HCI_ANNOTATIONS.IMAGE_ID]: '' };
         }
 
         break;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- https://github.com/harvester/harvester/issues/2212
### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
#### Image volume can be empty in VM template
1. Go to VM template page
2. Create a new version from the build-in templates or create a new template
3. One of the VM volumes should be `Image Volume` and it should be empty
4. Save
5. Repeat step 2 or Go to create a VM
6. Can select a image for the Image Volume

#### Container Volume can be rootdisk
1. Create a new VM
2. Add a container Volume and you can drag it to the first(rootdisk)
3. Create successfully

#### Throw errors if the image used by VM template is removed.
1. Create a VM template with a image
2. Remove this image
4. Go to VM template edit page
5. Throw error
6. Go to VM create page and use this template
7. Throw error
![WechatIMG203](https://user-images.githubusercontent.com/15041915/175438329-74e173dd-d380-413a-a218-c1c9b6c69575.png)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->