### PR TITLE
[Backport V1.0] HARVESTER: Cluster member and cluster owner see inconsistent statistics

### DIFF
--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -166,7 +166,8 @@ export const HCI = {
   DYNAMIC_SSHKEYS_USERS:        'harvesterhci.io/dynamic-ssh-key-users',
   VM_VOLUME_STATUS:             'harvesterhci.io/volume-status',
   IMAGE_SUFFIX:                 'harvesterhci.io/image-type',
-  OS_TYPE:                      'harvesterhci.io/os-type'
+  OS_TYPE:                      'harvesterhci.io/os-type',
+  HOST_REQUEST:                 'management.cattle.io/pod-requests',
 };
 
 // Annotations that can be on management.cattle.io.cluster to configure a custom badge

--- a/shell/detail/harvesterhci.io.host/HarvesterHostBasic.vue
+++ b/shell/detail/harvesterhci.io.host/HarvesterHostBasic.vue
@@ -208,6 +208,12 @@ export default {
 
       return !!this.$store.getters[`${ inStore }/schemaFor`](HCI.NODE_NETWORK);
     },
+
+    hasLonghornSchema() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+
+      return !!this.$store.getters[`${ inStore }/schemaFor`](LONGHORN.NODES);
+    },
   },
 
   methods: {
@@ -294,21 +300,36 @@ export default {
       <hr class="divider" />
       <h3>{{ t('harvester.host.tabs.monitor') }}</h3>
       <div class="row mb-20">
-        <div class="col span-4">
+        <div
+          class="col"
+          :class="{
+            'span-4': hasLonghornSchema,
+            'span-6': !hasLonghornSchema,
+          }"
+        >
           <HarvesterCPUUsed
             :row="value"
             :resource-name="t('node.detail.glance.consumptionGauge.cpu')"
             :show-used="true"
           />
         </div>
-        <div class="col span-4">
+        <div
+          class="col"
+          :class="{
+            'span-4': hasLonghornSchema,
+            'span-6': !hasLonghornSchema,
+          }"
+        >
           <HarvesterMemoryUsed
             :row="value"
             :resource-name="t('node.detail.glance.consumptionGauge.memory')"
             :show-used="true"
           />
         </div>
-        <div class="col span-4">
+        <div
+          v-if="hasLonghornSchema"
+          class="col span-4"
+        >
           <HarvesterStorageUsed
             :row="value"
             :resource-name="t('harvester.host.detail.storage')"

--- a/shell/list/harvesterhci.io.dashboard/index.vue
+++ b/shell/list/harvesterhci.io.dashboard/index.vue
@@ -172,7 +172,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentCluster']),
+    ...mapGetters(['currentCluster', 'isVirtualCluster']),
 
     accessibleResources() {
       const inStore = this.$store.getters['currentProduct'].inStore;
@@ -375,50 +375,22 @@ export default {
     },
 
     cpuReserved() {
-      const useful = this.pods.filter((pod) => {
-        const nodeName = pod?.spec?.nodeName;
-
-        return this.availableNodes.includes(nodeName);
-      }).reduce((sum, pod) => {
-        const containers = pod?.spec?.containers || [];
-
-        const containerCpuReserved = containers.reduce((sum, c) => {
-          sum += parseSi(c?.resources?.requests?.cpu || '0m');
-
-          return sum;
-        }, 0);
-
-        sum += containerCpuReserved;
-
-        return sum;
+      const useful = this.nodes.reduce((total, node) => {
+        return total + node.cpuReserved;
       }, 0);
 
       return {
-        total:  this.cpusTotal,
-        useful: Number(formatSi(useful)),
+        total: this.cpusTotal,
+        useful,
       };
     },
 
     ramReserved() {
-      const useful = this.pods.filter((pod) => {
-        const nodeName = pod?.spec?.nodeName;
-
-        return this.availableNodes.includes(nodeName);
-      }).reduce((sum, pod) => {
-        const containers = pod?.spec?.containers || [];
-
-        const containerMemoryReserved = containers.reduce((sum, c) => {
-          sum += parseSi(c?.resources?.requests?.memory || '0m', { increment: 1024 });
-
-          return sum;
-        }, 0);
-
-        sum += containerMemoryReserved;
-
-        return sum;
+      const useful = this.nodes.reduce((total, node) => {
+        return total + node.memoryReserved;
       }, 0);
 
-      return this.createMemoryValues(this.memoryTotal, useful);
+      return createMemoryValues(this.memoryTotal, useful);
     },
 
     availableNodes() {
@@ -583,7 +555,12 @@ export default {
       <h3 class="mt-40">
         {{ t('clusterIndexPage.sections.capacity.label') }}
       </h3>
-      <div class="hardware-resource-gauges">
+      <div
+        class="hardware-resource-gauges"
+        :class="{
+          live: !storageTotal,
+        }"
+      >
         <HardwareResourceGauge
           :name="t('harvester.dashboard.hardwareResourceGauge.cpu')"
           :reserved="cpuReserved"
@@ -595,6 +572,7 @@ export default {
           :used="ramUsed"
         />
         <HardwareResourceGauge
+          v-if="storageTotal"
           :name="t('harvester.dashboard.hardwareResourceGauge.storage')"
           :used="storageUsed"
           :reserved="storageReserved"

--- a/shell/list/harvesterhci.io.host/index.vue
+++ b/shell/list/harvesterhci.io.host/index.vue
@@ -44,6 +44,8 @@ export default {
 
     if (this.$store.getters['harvester/schemaFor'](LONGHORN.NODES)) {
       _hash.longhornNodes = this.$store.dispatch('harvester/findAll', { type: LONGHORN.NODES });
+    } else {
+      this.hasLonghornSchema = false;
     }
 
     if (this.$store.getters['harvester/schemaFor'](HCI.BLOCK_DEVICE)) {
@@ -57,8 +59,9 @@ export default {
 
   data() {
     return {
-      rows:            [],
-      hasMetricSchema: true
+      rows:              [],
+      hasMetricSchema:   true,
+      hasLonghornSchema: true,
     };
   },
 
@@ -86,12 +89,13 @@ export default {
       ];
 
       if (this.hasMetricSchema) {
+        const width = this.hasLonghornSchema ? '230' : '345';
         const metricCol = [
           {
             name:          'cpu',
             labelKey:      'node.detail.glance.consumptionGauge.cpu',
             value:         'id',
-            width:         '230',
+            width,
             formatter:     'HarvesterCPUUsed',
             formatterOpts: { showUsed: true },
           },
@@ -99,21 +103,26 @@ export default {
             name:          'memory',
             labelKey:      'node.detail.glance.consumptionGauge.memory',
             value:         'id',
-            width:         '230',
+            width,
             formatter:     'HarvesterMemoryUsed',
             formatterOpts: { showUsed: true },
           },
-          {
-            name:          'storage',
-            labelKey:      'tableHeaders.storage',
-            value:         'id',
-            width:         '230',
-            formatter:     'HarvesterStorageUsed',
-            formatterOpts: { showReserved: true },
-          }
         ];
 
         out.splice(-1, 0, ...metricCol);
+      }
+
+      if (this.hasLonghornSchema) {
+        const storageHeader = {
+          name:          'storage',
+          labelKey:      'tableHeaders.storage',
+          value:         'id',
+          width:         '230',
+          formatter:     'HarvesterStorageUsed',
+          formatterOpts: { showReserved: true },
+        };
+
+        out.splice(-1, 0, storageHeader);
       }
 
       out.push(AGE);

--- a/shell/models/harvester/node.js
+++ b/shell/models/harvester/node.js
@@ -231,40 +231,20 @@ export default class HciNode extends SteveModel {
     return pods.filter(p => p?.spec?.nodeName === this.id && p?.metadata?.name !== 'removing');
   }
 
+  get reserved() {
+    try {
+      return JSON.parse(this.metadata.annotations[HCI_ANNOTATIONS.HOST_REQUEST] || '{}');
+    } catch {
+      return {};
+    }
+  }
+
   get cpuReserved() {
-    const out = this.pods.reduce((sum, pod) => {
-      const containers = pod?.spec?.containers || [];
-
-      const containerCpuReserved = containers.reduce((sum, c) => {
-        sum += parseSi(c?.resources?.requests?.cpu || '0m');
-
-        return sum;
-      }, 0);
-
-      sum += containerCpuReserved;
-
-      return sum;
-    }, 0);
-
-    return out;
+    return parseSi(this.reserved.cpu || '0');
   }
 
   get memoryReserved() {
-    const out = this.pods.reduce((sum, pod) => {
-      const containers = pod?.spec?.containers || [];
-
-      const containerMemoryReserved = containers.reduce((sum, c) => {
-        sum += parseSi(c?.resources?.requests?.memory || '0m', { increment: 1024 });
-
-        return sum;
-      }, 0);
-
-      sum += containerMemoryReserved;
-
-      return sum;
-    }, 0);
-
-    return out;
+    return parseSi(this.reserved.memory || '0');
   }
 
   get canDelete() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes Cluster members and cluster owners see inconsistent statistics
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- https://github.com/harvester/harvester/issues/2386
### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Hide the storage gauge if the user has no auth request Longhorn API
- Node Reserved value obtain from node annotation, Cluster reserved is the total of node reserved.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

This PR will release to `https://releases.rancher.com/harvester-ui/dashboard/release-harvester-v1.0/index.html`, and it requires the latest Harvester version.

Case 1:
1. Login with admin/cluster member on rancher
- Check the Dashboard CPU, memory, and storage
- Check the Host list/detail CPU, memory, and storage

Case 2:
1. Login with admin on Harvester
- Check the Dashboard CPU, memory, and storage
- Check the Host list/detail CPU, memory, and storage

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->



### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![image](https://user-images.githubusercontent.com/18737885/178466893-ac8ab8ee-200f-4678-a280-efb3e1e97a3e.png)

![image](https://user-images.githubusercontent.com/18737885/178466997-036f6f64-1bd8-4629-8ff9-cf7f413c6b31.png)

![image](https://user-images.githubusercontent.com/18737885/178467058-d166def0-c9ce-4492-895a-1c35b96934f8.png)

