### PR TITLE
Harvester: display more info on deleting namespace dialog

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3847,6 +3847,7 @@ promptRemove:
   confirmName: "Enter <b>{nameToMatch}</b> below to confirm:"
   deleteAssociatedNamespaces: "Also delete the namespaces in this project:"
   willDeleteAssociatedNamespaces: "This will also delete all namespaces in the project: "
+  confirmRelatedResource: "Deleting the {type} will remove all the resources on this particular {type} and this is not revertable, are you sure you want to continue deleting {names}"
 
 promptRemoveApp:
   removeCrd: "Delete the CRD associated with this app"

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -3800,6 +3800,7 @@ promptRemove:
   attemptingToRemove: "你正在试图删除 {type}"
   protip: "提示：按住 {alternateLabel} 键的同时单击删除，以绕过此确认。"
   confirmName: "在下方输入 <b>{nameToMatch}</b> 以确认："
+  confirmRelatedResource: "删除 {type} 将删除这个特定 {type} 上的所有资源，这是不可恢复的，您确定要继续删除 {names} 吗？"
 
 promptRemoveApp:
   removeCrd: "删除与此应用关联的 CRD"

--- a/shell/components/dialog/harvester/ConfirmRelatedToRemoveDialog.vue
+++ b/shell/components/dialog/harvester/ConfirmRelatedToRemoveDialog.vue
@@ -1,0 +1,166 @@
+<script>
+import { mapState } from 'vuex';
+import { exceptionToErrorsArray } from '@shell/utils/error';
+import { alternateLabel } from '@shell/utils/platform';
+import AsyncButton from '@shell/components/AsyncButton';
+import { Banner } from '@components/Banner';
+import { Card } from '@components/Card';
+import { escapeHtml } from '@shell/utils/string';
+import CopyToClipboardText from '@shell/components/CopyToClipboardText';
+
+/**
+ * @name ConfirmRelatedToRemoveDialog
+ * @description Dialog component to confirm the related resources before removing the resource.
+ */
+export default {
+  name: 'ConfirmRelatedToRemoveDialog',
+
+  components: {
+    AsyncButton,
+    Banner,
+    Card,
+    CopyToClipboardText
+  },
+
+  props:  {
+    /**
+     * @property resources to be deleted.
+     * @type {Resource[]} Array of the resource model's instance
+     */
+    resources: {
+      type:     Array,
+      required: true
+    }
+  },
+
+  data() {
+    return { errors: [], confirmName: '' };
+  },
+
+  computed: {
+    ...mapState('action-menu', ['modalData']),
+
+    warningMessageKey() {
+      return this.modalData.warningMessageKey;
+    },
+
+    names() {
+      return this.resources.map(obj => obj.nameDisplay).slice(0, 5);
+    },
+
+    resourceNames() {
+      return this.names.reduce((res, name, i) => {
+        if (i >= 5) {
+          return res;
+        }
+        res += `<b>${ escapeHtml(name) }</b>`;
+        if (i === this.names.length - 1) {
+          res += this.plusMore;
+        } else {
+          res += i === this.resources.length - 2 ? ' and ' : ', ';
+        }
+
+        return res;
+      }, '');
+    },
+
+    nameToMatch() {
+      return this.resources[0].nameDisplay;
+    },
+
+    plusMore() {
+      const remaining = this.resources.length - this.names.length;
+
+      return this.t('promptRemove.andOthers', { count: remaining });
+    },
+
+    type() {
+      const types = new Set(this.resources.reduce((array, each) => {
+        array.push(each.type);
+
+        return array;
+      }, []));
+
+      if (types.size > 1) {
+        return this.t('generic.resource', { count: this.resources.length });
+      }
+
+      const schema = this.resources[0]?.schema;
+
+      if ( !schema ) {
+        return `resource${ this.resources.length === 1 ? '' : 's' }`;
+      }
+
+      return this.$store.getters['type-map/labelFor'](schema, this.resources.length);
+    },
+
+    deleteDisabled() {
+      return this.confirmName !== this.nameToMatch;
+    },
+
+    protip() {
+      return this.t('promptRemove.protip', { alternateLabel });
+    },
+  },
+
+  methods: {
+    escapeHtml,
+
+    close() {
+      this.confirmName = '';
+      this.errors = [];
+      this.$emit('close');
+    },
+
+    async remove(buttonDone) {
+      try {
+        await this.resources[0].remove();
+        buttonDone(true);
+        this.close();
+      } catch (e) {
+        this.errors = exceptionToErrorsArray(e);
+        buttonDone(false);
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <Card class="prompt-related" :show-highlight-border="false">
+    <h4 slot="title" class="text-default-text">
+      {{ t('promptRemove.title') }}
+    </h4>
+    <div slot="body" class="pl-10 pr-10">
+      <span
+        v-html="t(warningMessageKey, { type, names: resourceNames }, true)"
+      ></span>
+
+      <div class="mt-10 mb-10">
+        <span
+          v-html="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
+        ></span>
+      </div>
+      <div class="mb-10">
+        <CopyToClipboardText :text="nameToMatch" />
+      </div>
+      <input id="confirm" v-model="confirmName" type="text" />
+      <div class="text-info mt-20">
+        {{ protip }}
+      </div>
+      <Banner v-for="(error, i) in errors" :key="i" class="" color="error" :label="error" />
+    </div>
+    <template #actions>
+      <button class="btn role-secondary mr-10" @click="close">
+        {{ t('generic.cancel') }}
+      </button>
+      <AsyncButton mode="delete" class="btn bg-error ml-10" :disabled="deleteDisabled" @click="remove" />
+    </template>
+  </Card>
+</template>
+
+<style lang='scss' scoped>
+  .actions {
+    text-align: right;
+  }
+</style>

--- a/shell/models/harvester/namespace.js
+++ b/shell/models/harvester/namespace.js
@@ -1,0 +1,36 @@
+import { insertAt } from '@shell/utils/array';
+import SteveModel from '@shell/plugins/steve/steve-class';
+
+export default class HciNamespace extends SteveModel {
+  get _availableActions() {
+    const out = super._availableActions;
+    const remove = out.findIndex(a => a.action === 'promptRemove');
+
+    const promptRemove = {
+      action:     'promptRemove',
+      altAction:  'remove',
+      label:      this.t('action.remove'),
+      icon:       'icon icon-trash',
+      bulkable:   true,
+      enabled:    this.canDelete,
+      bulkAction: 'promptRemove',
+      weight:     -10,
+    };
+
+    if (remove > -1) {
+      out.splice(remove, 1);
+    }
+
+    insertAt(out, out.length - 1, promptRemove);
+
+    return out;
+  }
+
+  promptRemove(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      warningMessageKey: 'promptRemove.confirmRelatedResource',
+      component:         'harvester/ConfirmRelatedToRemoveDialog'
+    });
+  }
+}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/2591

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

1. Go to Projects/Namespaces page
2. Remove one or more namespaces
3. The warning tips `Deleting the Namespace(s) will remove all the resources on this particular Namespace(s) and this is not revertable, are you sure you want to continue deleting XXX` should be visible on the dialog

![image](https://user-images.githubusercontent.com/15041915/183547621-2ba408af-3c5a-43e7-8f36-ac870e69aebc.png)


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->