### PR TITLE
HARVESTER: Fix unable to add addition disks on Host

### DIFF
--- a/shell/edit/harvesterhci.io.host/HarvesterDisk.vue
+++ b/shell/edit/harvesterhci.io.host/HarvesterDisk.vue
@@ -80,7 +80,7 @@ export default {
 
       const systems = ['ext4', 'XFS'];
 
-      if (lastFormattedAt) {
+      if (lastFormattedAt || this.value?.blockDevice?.childParts?.length > 0) {
         return true;
       } else if (systems.includes(fileSystem)) {
         return false;

--- a/shell/edit/harvesterhci.io.host/index.vue
+++ b/shell/edit/harvesterhci.io.host/index.vue
@@ -239,7 +239,9 @@ export default {
       let forceFormatted = true;
       const systems = ['ext4', 'XFS'];
 
-      if (lastFormattedAt) {
+      if (disk.childParts?.length > 0) {
+        forceFormatted = true;
+      } else if (lastFormattedAt) {
         forceFormatted = false;
       } else if (systems.includes(disk?.status?.deviceStatus?.fileSystem?.type)) {
         forceFormatted = false;
@@ -359,7 +361,7 @@ export default {
             value:    d.id,
             action:   this.addDisk,
             kind:     !parentDevice ? 'group' : '',
-            disabled: !!(d.childParts.length > 0 || isChildAdded),
+            disabled: !!isChildAdded,
             group:    parentDevice || devPath,
             isParent: !!parentDevice,
           };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes unable to add addition disks on Host
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/2551

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Allow the disk with partitions option can be select
- Force formatted is required for the disk with a partitions

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->