### PR TITLE
fix curresource footer so it is never behind form elements

### DIFF
--- a/shell/components/CruResourceFooter.vue
+++ b/shell/components/CruResourceFooter.vue
@@ -115,6 +115,7 @@ export default {
   display: flex;
   justify-content: flex-end;
   margin-top: 20px;
+  z-index: 99;
 
   .btn {
     margin-left: 20px;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes [#2843 ](https://github.com/harvester/harvester/issues/2843)

Update `CruResourceFooter`: this component should never appear underneath others.

![Screen Shot 2022-09-28 at 3 26 53 PM](https://user-images.githubusercontent.com/42977925/192899657-4864d8f0-a64c-4912-bfd7-2396cdeac8b5.png)
