### PR TITLE
Port harvester service translations

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -771,25 +771,6 @@ harvester:
   projectNamespace:
     label: Projects/Namespaces
 
-  service:
-    title: Add-on Config
-    ipam:
-      label: IPAM
-    healthCheckPort:
-      label: Health Check Port
-    healthCheckSuccessThreshold:
-      label: Health Check Success Threshold
-      description: If the number of times the prober continuously detects an address successfully reaches the success threshold, then the backend server can start to forward traffic.
-    healthCheckFailureThreshold:
-      label: Health Check Failure Threshold
-      description: The backend server will stop forwarding traffic if the number of health check failures reaches the failure threshold.
-    healthCheckPeriod:
-      label: Health Check Period
-    healthCheckTimeout:
-      label: Health Check Timeout
-    healthCheckEnabled:
-      label: Health Check
-
   vip:
     namespace:
       label: Namespace

--- a/pkg/harvester/l10n/zh-hans.yaml
+++ b/pkg/harvester/l10n/zh-hans.yaml
@@ -762,25 +762,6 @@ harvester:
   projectNamespace:
     label: 项目/命名空间
 
-  service:
-    title: 附加配置
-    ipam:
-      label: IPAM
-    healthCheckPort:
-      label: 健康检查端口
-    healthCheckSuccessThreshold:
-      label: 健康检查成功阙值
-      description: 如果探针连续检测到某个地址的成功次数达到成功阈值，后端服务器就可以开始转发流量。
-    healthCheckFailureThreshold:
-      label: 健康检查失败阈值
-      description: 如果健康检查失败的数量达到失败阈值，后端服务器将停止转发流量。
-    healthCheckPeriod:
-      label: 健康检查周期
-    healthCheckTimeout:
-      label: 健康检查超时
-    healthCheckEnabled:
-      label: 健康检查
-
   vip:
     namespace:
       label: 命名空间

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4320,6 +4320,24 @@ servicesPage:
     placeholder: e.g. my.database.example.com
     input:
       label: DNS Name
+  harvester:
+    title: Add-on Config
+    ipam:
+      label: IPAM
+    healthCheckPort:
+      label: Health Check Port
+    healthCheckSuccessThreshold:
+      label: Health Check Success Threshold
+      description: If the number of times the prober continuously detects an address successfully reaches the success threshold, then the backend server can start to forward traffic.
+    healthCheckFailureThreshold:
+      label: Health Check Failure Threshold
+      description: The backend server will stop forwarding traffic if the number of health check failures reaches the failure threshold.
+    healthCheckPeriod:
+      label: Health Check Period
+    healthCheckTimeout:
+      label: Health Check Timeout
+    healthCheckEnabled:
+      label: Health Check
   ips:
     define: Service Ports
     clusterIpHelpText: The Cluster IP address must be within the CIDR range configured for the API server.

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -4315,6 +4315,24 @@ servicesPage:
     placeholder: 例如：my.database.example.com
     input:
       label: DNS 名称
+  harvester:
+    title: 附加配置
+    ipam:
+      label: IPAM
+    healthCheckPort:
+      label: 健康检查端口
+    healthCheckSuccessThreshold:
+      label: 健康检查成功阙值
+      description: 如果探针连续检测到某个地址的成功次数达到成功阈值，后端服务器就可以开始转发流量。
+    healthCheckFailureThreshold:
+      label: 健康检查失败阈值
+      description: 如果健康检查失败的数量达到失败阈值，后端服务器将停止转发流量。
+    healthCheckPeriod:
+      label: 健康检查周期
+    healthCheckTimeout:
+      label: 健康检查超时
+    healthCheckEnabled:
+      label: 健康检查
   ips:
     define: 服务端口
     clusterIpHelpText: 集群 IP 地址必须在为 API server 配置的 CIDR 范围内。

--- a/shell/components/HarvesterServiceAddOnConfig.vue
+++ b/shell/components/HarvesterServiceAddOnConfig.vue
@@ -100,7 +100,7 @@ export default {
       const errors = [];
 
       if (this.healthCheckEnabled && !this.healthcheckPort) {
-        errors.push(this.t('validation.required', { key: this.t('harvester.service.healthCheckPort.label') }, true));
+        errors.push(this.t('validation.required', { key: this.t('servicesPage.harvester.healthCheckPort.label') }, true));
       }
 
       if (errors.length > 0) {
@@ -131,7 +131,7 @@ export default {
           v-model="ipam"
           :mode="mode"
           :options="ipamOptions"
-          :label="t('harvester.service.ipam.label')"
+          :label="t('servicesPage.harvester.ipam.label')"
           :disabled="mode === 'edit'"
         />
       </div>
@@ -143,7 +143,7 @@ export default {
           v-model="healthCheckEnabled"
           :mode="mode"
           name="healthCheckEnabled"
-          :label="t('harvester.service.healthCheckEnabled.label')"
+          :label="t('servicesPage.harvester.healthCheckEnabled.label')"
           :labels="[t('generic.disabled'),t('generic.enabled')]"
           :options="[false, true]"
         />
@@ -157,7 +157,7 @@ export default {
             :mode="mode"
             :options="portOptions"
             required
-            :label="t('harvester.service.healthCheckPort.label')"
+            :label="t('servicesPage.harvester.healthCheckPort.label')"
           />
         </div>
         <div class="col span-6">
@@ -165,8 +165,8 @@ export default {
             v-model="healthCheckSuccessThreshold"
             :mode="mode"
             type="number"
-            :label="t('harvester.service.healthCheckSuccessThreshold.label')"
-            :tooltip="t('harvester.service.healthCheckSuccessThreshold.description')"
+            :label="t('servicesPage.harvester.healthCheckSuccessThreshold.label')"
+            :tooltip="t('servicesPage.harvester.healthCheckSuccessThreshold.description')"
           />
         </div>
       </div>
@@ -176,8 +176,8 @@ export default {
             v-model="healthCheckFailureThreshold"
             :mode="mode"
             type="number"
-            :label="t('harvester.service.healthCheckFailureThreshold.label')"
-            :tooltip="t('harvester.service.healthCheckFailureThreshold.description')"
+            :label="t('servicesPage.harvester.healthCheckFailureThreshold.label')"
+            :tooltip="t('servicesPage.harvester.healthCheckFailureThreshold.description')"
           />
         </div>
         <div class="col span-6">
@@ -185,7 +185,7 @@ export default {
             v-model="healthCheckPeriod"
             :mode="mode"
             type="number"
-            :label="t('harvester.service.healthCheckPeriod.label')"
+            :label="t('servicesPage.harvester.healthCheckPeriod.label')"
           />
         </div>
       </div>
@@ -195,7 +195,7 @@ export default {
             v-model="healthCheckTimeout"
             :mode="mode"
             type="number"
-            :label="t('harvester.service.healthCheckTimeout.label')"
+            :label="t('servicesPage.harvester.healthCheckTimeout.label')"
           />
         </div>
       </div>

--- a/shell/components/form/WorkloadPorts.vue
+++ b/shell/components/form/WorkloadPorts.vue
@@ -366,7 +366,7 @@ export default {
             v-model="row._ipam"
             :mode="mode"
             :options="ipamOptions"
-            :label="t('harvester.service.ipam.label')"
+            :label="t('servicesPage.harvester.ipam.label')"
             :disabled="mode === 'edit'"
             @input="queueUpdate"
           />
@@ -376,7 +376,7 @@ export default {
             v-model="rows[ipamIndex]._ipam"
             :mode="mode"
             :options="ipamOptions"
-            :label="t('harvester.service.ipam.label')"
+            :label="t('servicesPage.harvester.ipam.label')"
             :disabled="true"
             @input="queueUpdate"
           />

--- a/shell/edit/service.vue
+++ b/shell/edit/service.vue
@@ -453,7 +453,7 @@ export default {
       <Tab
         v-if="showHarvesterAddOnConfig"
         name="add-on-config"
-        :label="t('harvester.service.title')"
+        :label="t('servicesPage.harvester.title')"
         :weight="-1"
       >
         <HarvesterServiceAddOnConfig


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/harvester/harvester/issues/2929 in conjunction with:
https://github.com/rancher/dashboard/pull/7187 (2.6.9)
https://github.com/rancher/dashboard/pull/7189 (master)
https://github.com/rancher/dashboard/pull/7190 (2.6.9)
https://github.com/rancher/dashboard/pull/7191 (master)


There are four PRs because I forgot to move the zh-hans translation strings. 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The  service add-on config UI and WorkloadPorts ipam option are available in clusters provisioned on an imported harvester cluster: since these components may be loaded without a harvester plugin having been loaded, the translation strings must stay in `shell`

