### PR TITLE
disable view/edit as yaml, clone, and delete actions for pci devices

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
@@ -1,7 +1,7 @@
 <script>
 import ResourceTable from '@shell/components/ResourceTable';
 import { HCI } from '../../../types';
-import { STATE, NAME } from '@shell/config/table-headers';
+import { STATE, SIMPLE_NAME } from '@shell/config/table-headers';
 export default {
   name: 'ListPciDevices',
 
@@ -29,7 +29,7 @@ export default {
     const isSingleProduct = this.$store.getters['isSingleProduct'];
     const headers = [
       { ...STATE },
-      NAME,
+      SIMPLE_NAME,
       {
         name:          'description',
         labelKey:      'tableHeaders.description',

--- a/pkg/harvester/models/devices.harvesterhci.io.pcidevice.js
+++ b/pkg/harvester/models/devices.harvesterhci.io.pcidevice.js
@@ -49,6 +49,14 @@ export default class PCIDevice extends SteveModel {
     return out;
   }
 
+  get canYaml() {
+    return false;
+  }
+
+  get canDelete() {
+    return false;
+  }
+
   get passthroughClaim() {
     const passthroughClaims = this.$getters['all'](HCI.PCI_CLAIM) || [];
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/harvester/harvester/issues/2925
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
* pci device name in table is no longer clickable
* view as yaml, edit yaml, clone, and delete actions are disabled for pci devices
