### PR TITLE
HARVESTER: add embedded ui of rancher and longhorn ui to support page

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -785,6 +785,13 @@ harvester:
     kubeconfig:
       title: Download KubeConfig
       titleDescription: Download kubeconfig for debugging.
+    internal:
+      rancher:
+        title: Access Embedded Rancher UI
+        titleDescription: We only support to use the embedded Rancher dashboard for debugging and validation purpose. For Rancher's multi-cluster and multi-tenant integration, please refer to the docs <a target="_blank" href="https://docs.harvesterhci.io/v1.1/rancher/rancher-integration" rel="noopener noreferrer nofollow">here</a>.
+      longhorn:
+        title: Access Embedded Longhorn UI
+        titleDescription: We only support to use the embedded Longhorn UI for debugging and validation purpose.
 
   namespace:
     label: Namespaces

--- a/pkg/harvester/pages/c/_cluster/support/index.vue
+++ b/pkg/harvester/pages/c/_cluster/support/index.vue
@@ -1,5 +1,6 @@
 <script>
 import { mapGetters } from 'vuex';
+import { mapPref, DEV } from '@shell/store/prefs';
 import BannerGraphic from '@shell/components/BannerGraphic';
 import IndentedPanel from '@shell/components/IndentedPanel';
 import HarvesterSupportBundle from '../../../../dialog/HarvesterSupportBundle';
@@ -31,6 +32,7 @@ export default {
 
   computed: {
     ...mapGetters(['currentCluster']),
+    dev: mapPref(DEV),
 
     title() {
       return 'harvester.support.title';
@@ -43,6 +45,28 @@ export default {
         SCHEMA,
         HCI.SUPPORT_BUNDLE
       );
+    },
+
+    internalPrefix() {
+      const host = window.location.host;
+      const prefix = window.location.pathname.replace(this.$route.path, '');
+      const params = this.$route?.params;
+
+      return {
+        host, prefix, params
+      };
+    },
+
+    rancherLink() {
+      const { host, prefix, params } = this.internalPrefix;
+
+      return `https://${ host }${ prefix }/c/${ params.cluster }/explorer`;
+    },
+
+    longhornLink() {
+      const { host, params } = this.internalPrefix;
+
+      return `https://${ host }/k8s/clusters/${ params.cluster }/api/v1/namespaces/longhorn-system/services/http:longhorn-frontend:80/proxy/#/dashboard`;
     }
   },
 
@@ -78,7 +102,7 @@ export default {
               </button>
             </div>
           </div>
-          <div class="box mb-20 box-primary">
+          <div class="box box-primary" :class="{'mb-20': dev }">
             <h2>
               {{ t('harvester.support.kubeconfig.title') }}
             </h2>
@@ -93,6 +117,28 @@ export default {
               >
                 {{ t('harvester.support.kubeconfig.title') }}
               </button>
+            </div>
+          </div>
+          <div v-if="dev" class="row">
+            <div class="col span-6 box box-primary">
+              <h2>
+                <a rel="nofollow noopener noreferrer" target="_blank" :href="rancherLink">{{ t('harvester.support.internal.rancher.title') }} <i class="icon icon-external-link" /></a>
+              </h2>
+              <div>
+                <p class="warning">
+                  <t k="harvester.support.internal.rancher.titleDescription" :raw="true" />
+                </p>
+              </div>
+            </div>
+            <div class="col span-6 box box-primary">
+              <h2>
+                <a rel="nofollow noopener noreferrer" target="_blank" :href="longhornLink">{{ t('harvester.support.internal.longhorn.title') }} <i class="icon icon-external-link" /></a>
+              </h2>
+              <div>
+                <p class="warning">
+                  <t k="harvester.support.internal.longhorn.titleDescription" :raw="true" />
+                </p>
+              </div>
             </div>
           </div>
         </div>
@@ -155,5 +201,11 @@ export default {
   &:focus {
     background-color: transparent;
   }
+}
+
+.warning {
+  margin: 0 -5px 0 -5px;
+  padding: 5px;
+  background-color: var(--warning-banner-bg);
 }
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/2765

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

1. Go to support page
2. Both of rancher link and longhorn link will not be visible.
3. Go to user preference page
4. Enable DEV mode
5. Back to support page
6. Both of rancher link and longhorn link will be visible.
7. Click links will open a new tab with rancher/longhorn embedded UI.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![image (5)](https://user-images.githubusercontent.com/15041915/202392762-4cd02aea-3947-47fe-b120-bf7a976db48c.png)
