### PR TITLE
HARVESTER: duplicate receiver name is invalid now

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.monitoring.alertmanagerconfig/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.monitoring.alertmanagerconfig/index.vue
@@ -91,7 +91,6 @@ export default {
   },
 
   computed: {
-
     editorMode() {
       if ( this.mode === _VIEW ) {
         return EDITOR_MODES.VIEW_CODE;
@@ -101,7 +100,6 @@ export default {
     },
   },
   methods: {
-
     translateReceiverTypes() {
       return this.receiverTypes.map((receiverType) => {
         return {
@@ -208,7 +206,7 @@ export default {
           @clickedActionButton="setActionMenuState"
         >
           <template #header-button>
-            <nuxt-link v-if="createReceiverLink && createReceiverLink.name" :to="createReceiverLink">
+            <nuxt-link v-if="createReceiverLink && createReceiverLink.name" :to="mode !== create ? createReceiverLink : {}">
               <button
                 class="btn role-primary"
                 :disabled="mode === create"

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2871,6 +2871,8 @@ monitoring:
       new: Create default config
       radio:
         label: Config Secret
+    validation:
+      duplicatedReceiverName: 'Duplicate name of receiver'
     templates:
       keyLabel: File Name
       label: Template Files

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
@@ -248,6 +248,17 @@ export default {
         return;
       }
 
+      const receiversArray = this.alertmanagerConfigResource.spec.receivers;
+      const receiverNamesArray = receiversArray.map(R => R.name);
+      const receiversSet = new Set(receiverNamesArray);
+
+      if (receiversArray.length !== receiversSet.size) {
+        this.errors.push(this.$store.getters['i18n/t']('monitoring.alerting.validation.duplicatedReceiverName'));
+        buttonDone(false);
+
+        return;
+      }
+
       this.saveOverride(buttonDone);
     }
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- ~Is this a multi-tenancy feature/bug?~
    - ~[ ] Yes, the relevant RBAC changes are at:~
- ~Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?~
    - ~[ ] Yes, the relevant PR is at:~
- ~Are backend engineers aware of UI changes?~
    - ~[ ] Yes, the backend owner is:~


<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/2798

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

1. Route tab will only be visible on `AlertmanagerConfig` edit page.
2. Duplicate name of receiver is invalid, can not be created.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->