### PR TITLE
HARVESTER: Add longhorn volume ready property

### DIFF
--- a/pkg/harvester/list/harvesterhci.io.volume.vue
+++ b/pkg/harvester/list/harvesterhci.io.volume.vue
@@ -4,7 +4,7 @@ import ResourceTable from '@shell/components/ResourceTable';
 import HarvesterVolumeState from '../formatters/HarvesterVolumeState';
 
 import { allHash } from '@shell/utils/promise';
-import { PV, PVC, SCHEMA } from '@shell/config/types';
+import { PV, PVC, SCHEMA, LONGHORN } from '@shell/config/types';
 import { HCI, VOLUME_SNAPSHOT } from '../types';
 import { STATE, AGE, NAME, NAMESPACE } from '@shell/config/table-headers';
 
@@ -26,9 +26,10 @@ export default {
 
   async fetch() {
     const _hash = {
-      pvcs: this.$store.dispatch('harvester/findAll', { type: PVC }),
-      pvs:  this.$store.dispatch('harvester/findAll', { type: PV }),
-      vms:  this.$store.dispatch('harvester/findAll', { type: HCI.VM }),
+      pvcs:            this.$store.dispatch('harvester/findAll', { type: PVC }),
+      pvs:             this.$store.dispatch('harvester/findAll', { type: PV }),
+      vms:             this.$store.dispatch('harvester/findAll', { type: HCI.VM }),
+      longhornVolumes: this.$store.dispatch('harvester/findAll', { type: LONGHORN.VOLUMES }),
     };
 
     const volumeSnapshotSchema = this.$store.getters['harvester/schemaFor'](VOLUME_SNAPSHOT);

--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { _CLONE } from '@shell/config/query-params';
 import pick from 'lodash/pick';
 import { HCI, VOLUME_SNAPSHOT } from '../../types';
-import { PV } from '@shell/config/types';
+import { PV, LONGHORN } from '@shell/config/types';
 import { DESCRIPTION } from '@shell/config/labels-annotations';
 import { HCI as HCI_ANNOTATIONS } from '@/pkg/harvester/config/labels-annotations';
 import { findBy } from '@shell/utils/array';
@@ -102,7 +102,7 @@ export default class HciPv extends HarvesterResource {
     const ownedBy = this?.metadata?.annotations?.[HCI_ANNOTATIONS.OWNED_BY];
     const volumeError = this.relatedPV?.metadata?.annotations?.[HCI_ANNOTATIONS.VOLUME_ERROR];
     const degradedVolume = volumeError === DEGRADED_ERROR;
-    const status = this?.status?.phase === 'Bound' && !volumeError ? 'Ready' : 'Not Ready';
+    const status = this?.status?.phase === 'Bound' && !volumeError && this.isLonghornVolumeReady ? 'Ready' : 'Not Ready';
 
     const conditions = this?.status?.conditions || [];
 
@@ -211,6 +211,31 @@ export default class HciPv extends HarvesterResource {
     }
 
     return false;
+  }
+
+  get longhornVolume() {
+    const inStore = this.$rootGetters['currentProduct'].inStore;
+
+    return this.$rootGetters[`${ inStore }/all`](LONGHORN.VOLUMES).find(v => v.metadata?.name === this.spec?.volumeName);
+  }
+
+  // https://github.com/longhorn/longhorn-manager/blob/master/api/model.go#L1151
+  get isLonghornVolumeReady() {
+    let ready = true;
+    const longhornVolume = this.longhornVolume || {};
+
+    const scheduledCondition = (longhornVolume?.status?.conditions).find(c => c.type === 'scheduled') || {};
+
+    if ((longhornVolume?.spec?.nodeID === '' && longhornVolume?.status?.state !== 'detached') ||
+          (longhornVolume?.status?.state === 'detached' && scheduledCondition.status !== 'True') ||
+          longhornVolume?.status?.robustness === 'faulted' ||
+          longhornVolume?.status?.restoreRequired ||
+          longhornVolume?.status?.cloneStatus?.state === 'failed'
+    ) {
+      ready = false;
+    }
+
+    return ready;
   }
 
   get relatedVolumeSnapshotCounts() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
~- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:~
~- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:~
~- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:~

Add longhorn volume ready property
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/3026

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The ready property is imported from https://github.com/longhorn/longhorn-manager/blob/master/api/model.go#L1151

Most of the time the state will show `Degraded`, only the PV annotation did not have `longhorn.io/volume-scheduling-error` the state will shows `Not Ready`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://user-images.githubusercontent.com/18737885/211805529-72c63a17-4260-4085-9aa6-a91023f861e8.png)
