### PR TITLE
HARVESTER: Hide project member

### DIFF
--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -11,6 +11,7 @@ import SortableTable from '@shell/components/SortableTable';
 import { mapGetters } from 'vuex';
 import { canViewProjectMembershipEditor } from '@shell/components/form/Members/ProjectMembershipEditor.vue';
 import { allHash } from '@shell/utils/promise';
+import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 
 /**
  * Explorer members page.
@@ -202,6 +203,9 @@ export default {
     canEditClusterMembers() {
       return this.normanClusterRTBSchema?.collectionMethods.find(x => x.toLowerCase() === 'post');
     },
+    isHarvester() {
+      return this.$store.getters['currentProduct'].inStore === HARVESTER;
+    },
   },
   methods: {
     getMgmtProjectId(group) {
@@ -274,7 +278,7 @@ export default {
         />
       </Tab>
       <Tab
-        v-if="canManageProjectMembers"
+        v-if="canManageProjectMembers && !isHarvester"
         name="project-membership"
         label="Project Membership"
       >


### PR DESCRIPTION
Cluster members adding project members creates two of the same, so hide it in v1.1.2 and consider letting go of it in v1.2.0