### PR TITLE
HARVESTER: Fix VlanConfig state display active but actual is "Not Ready"

### DIFF
--- a/pkg/harvester/list/network.harvesterhci.io.clusternetwork.vue
+++ b/pkg/harvester/list/network.harvesterhci.io.clusternetwork.vue
@@ -6,6 +6,7 @@ import Masthead from '@shell/components/ResourceList/Masthead';
 import { allHash } from '@shell/utils/promise';
 import { STATE, AGE, NAME } from '@shell/config/table-headers';
 import { mapPref, GROUP_RESOURCES } from '@shell/store/prefs';
+import { NODE } from '@shell/config/types';
 
 import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../config/harvester';
 import { CLUSTER_NETWORK } from '../config/query-params';
@@ -26,6 +27,8 @@ export default {
     await allHash({
       configs:         this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.VLAN_CONFIG }),
       clusterNetworks: this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.CLUSTER_NETWORK }),
+      vlanStatuses:    this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.VLAN_STATUS }),
+      nodes:           this.$store.dispatch(`${ inStore }/findAll`, { type: NODE })
     });
   },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
~- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:~
~- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:~
~- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:~

Fixes VlanConfig state display active but actual is "Not Ready"
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/3488

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/18737885/219615138-51cefe4c-e36e-4253-914f-96c97ced15d0.png">
