### PR TITLE
HARVESTER: Fix vlan status issue

### DIFF
--- a/pkg/harvester/components/settings/storage-network.vue
+++ b/pkg/harvester/components/settings/storage-network.vue
@@ -8,6 +8,8 @@ import { _EDIT } from '@shell/config/query-params';
 import { Banner } from '@components/Banner';
 import Tip from '@shell/components/Tip';
 import { HCI } from '../../types';
+import { allHash } from '@shell/utils/promise';
+import { NODE } from '@shell/config/types';
 
 export default {
   name: 'HarvesterEditStorageNetwork',
@@ -43,7 +45,11 @@ export default {
   async fetch() {
     const inStore = this.$store.getters['currentProduct'].inStore;
 
-    await this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.CLUSTER_NETWORK });
+    await allHash({
+      clusterNetworks: this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.CLUSTER_NETWORK }),
+      vlanStatus:      this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.VLAN_STATUS }),
+      nodes:           this.$store.dispatch(`${ inStore }/findAll`, { type: NODE }),
+    });
   },
 
   data() {
@@ -84,11 +90,10 @@ export default {
       const clusterNetworks = this.$store.getters[`${ inStore }/all`](HCI.CLUSTER_NETWORK) || [];
 
       return clusterNetworks.map((n) => {
-        const readyCondition = (n?.status?.conditions || []).find(c => c.type === 'ready') || {};
-        const disabled = readyCondition?.status !== 'True';
+        const disabled = !n.isReadyForStorageNetwork;
 
         return {
-          label: disabled ? `${ n.id } (${ this.t('fleet.fleetSummary.state.notReady') })` : n.id,
+          label: disabled ? `${ n.id } (${ this.t('generic.notReady') })` : n.id,
           value: n.id,
           disabled,
         };

--- a/pkg/harvester/components/settings/storage-network.vue
+++ b/pkg/harvester/components/settings/storage-network.vue
@@ -84,9 +84,13 @@ export default {
       const clusterNetworks = this.$store.getters[`${ inStore }/all`](HCI.CLUSTER_NETWORK) || [];
 
       return clusterNetworks.map((n) => {
+        const readyCondition = (n?.status?.conditions || []).find(c => c.type === 'ready') || {};
+        const disabled = readyCondition?.status !== 'True';
+
         return {
-          label: n.id,
+          label: disabled ? `${ n.id } (${ this.t('fleet.fleetSummary.state.notReady') })` : n.id,
           value: n.id,
+          disabled,
         };
       });
     },
@@ -205,7 +209,6 @@ export default {
           <div class="box">
             <div class="key">
               {{ t('harvester.setting.storageNetwork.exclude.label') }}
-              <span class="required">*</span>
             </div>
           </div>
         </template>

--- a/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
+++ b/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
@@ -86,11 +86,10 @@ export default {
       const clusterNetworks = this.$store.getters[`${ inStore }/all`](HCI.CLUSTER_NETWORK) || [];
 
       return clusterNetworks.map((n) => {
-        const readyCondition = (n?.status?.conditions || []).find(c => c.type === 'ready') || {};
-        const disabled = readyCondition?.status !== 'True';
+        const disabled = !n.isReady;
 
         return {
-          label: disabled ? `${ n.id } (${ this.t('fleet.fleetSummary.state.notReady') })` : n.id,
+          label: disabled ? `${ n.id } (${ this.t('generic.notReady') })` : n.id,
           value: n.id,
           disabled,
         };

--- a/pkg/harvester/models/network.harvesterhci.io.vlanstatus.js
+++ b/pkg/harvester/models/network.harvesterhci.io.vlanstatus.js
@@ -1,0 +1,12 @@
+import { findBy } from '@shell/utils/array';
+
+import HarvesterResource from './harvester';
+
+export default class HciVlanStatus extends HarvesterResource {
+  get isReady() {
+    const conditions = this.status?.conditions || [];
+    const readyCondition = findBy(conditions, 'type', 'ready') || {};
+
+    return readyCondition.status === 'True';
+  }
+}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
~- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:~
~- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:~
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @yaocw2020 

Fix VLAN status issue
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/3488

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- The VLAN status should filter by VLAN config and the selected node name
- Cluster network in storage-network setting also disabled it when its conditions are not ready

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![image](https://user-images.githubusercontent.com/18737885/220294735-087ccd7e-4175-49a3-842c-6666e7d0bf00.png)

![image](https://user-images.githubusercontent.com/18737885/220294777-d2002ab7-1032-45f5-9945-390c3fcbf7da.png)

![image](https://user-images.githubusercontent.com/18737885/220294942-70834ea7-25cc-4144-bea8-62d623e4d83b.png)
