### PR TITLE
fix: Toss Out Invalid Amount On VFs For SR-IOV

### DIFF
--- a/pkg/harvester/dialog/EnableSriovDevice.vue
+++ b/pkg/harvester/dialog/EnableSriovDevice.vue
@@ -39,6 +39,13 @@ export default {
 
       try {
         this.resources[0].spec.numVFs = this.numVFs;
+        if (this.resources[0].spec.numVFs <= 0) {
+          this.resources[0].spec.numVFs = 0;
+          this.numVFs = 0;
+          this.close();
+
+          return;
+        }
         await actionResource.save();
         buttonCb(true);
         this.close();


### PR DESCRIPTION
* toss out anything less than or equal to zero for the SR-IOV device virtual function addresses
* avoid making an API call out to the endpoint, reducing network chatter

Resolves: github.com/harvester/harvester/issues/3977

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->