### PR TITLE
HARVESTER: We can set negative integer value to Termination Grace Period field and write into VM yaml

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -635,6 +635,7 @@ export default {
                 :suffix="terminationGracePeriodSeconds == 1 ? 'Second' : 'Seconds'"
                 :label="t('harvester.virtualMachine.terminationGracePeriodSeconds.label')"
                 :mode="mode"
+                positive
                 @input="updateTerminationGracePeriodSeconds"
               />
             </div>

--- a/shell/components/form/UnitInput.vue
+++ b/shell/components/form/UnitInput.vue
@@ -126,7 +126,12 @@ export default {
     delay: {
       type:    Number,
       default: 0
-    }
+    },
+
+    positive: {
+      type:    Boolean,
+      default: false,
+    },
   },
 
   computed: {
@@ -193,6 +198,10 @@ export default {
 
     update(inputValue) {
       let out = inputValue === '' ? null : inputValue;
+
+      if (this.positive && inputValue < 0) {
+        out = 0;
+      }
 
       if (this.outputModifier) {
         out = out === null ? null : `${ inputValue }${ this.unit }`;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
~- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:~
~- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:~
~- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:~

Fixes We can set negative integer value to Termination Grace Period field and write into VM yaml
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/3946

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Add positive for UnitInput component

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->