### PR TITLE
HARVESTER: Add the insufficient resource to vm annotation

### DIFF
--- a/pkg/harvester/config/labels-annotations.js
+++ b/pkg/harvester/config/labels-annotations.js
@@ -42,4 +42,5 @@ export const HCI = {
   NODE_MANUFACTURER:            'manufacturer',
   NODE_MODEL:                   'model',
   NODE_SERIAL_NUMBER:           'serialNumber',
+  VM_INSUFFICIENT:              'harvesterhci.io/insufficientResourceQuota',
 };

--- a/pkg/harvester/formatters/HarvesterVmState.vue
+++ b/pkg/harvester/formatters/HarvesterVmState.vue
@@ -54,6 +54,10 @@ export default {
         out.push(this.row?.migrationMessage.message);
       }
 
+      if (this.row.warningMessage?.message) {
+        out.push(this.row.warningMessage?.message);
+      }
+
       return out;
     }
   },

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -713,6 +713,10 @@ export default class VirtVm extends HarvesterResource {
   }
 
   get warningMessage() {
+    if (this.metadata?.annotations[HCI_ANNOTATIONS.VM_INSUFFICIENT]) {
+      return { message: this.metadata?.annotations[HCI_ANNOTATIONS.VM_INSUFFICIENT] };
+    }
+
     const conditions = get(this, 'status.conditions');
     const vmFailureCond = findBy(conditions, 'type', 'Failure');
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
~- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:~
~- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:~
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is: @chrisho 

Add the insufficient resource to vm annotation
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- https://github.com/harvester/harvester/issues/3944
### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Verify Steps:
1. Set over-commit CPU and memory to 100%
2. Create a project with 2000m cpu
3. Create a namespace with 2000m cpu
4. Create 10 VMs with 2cpu and 4Gi
5. Check the error message in VM list

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/harvester/dashboard/assets/18737885/befc6a41-deda-4c70-9edf-aa6153c71a95)
