### PR TITLE
HARVESTER: Should give a chance to force format or fsck for the corrupted additional disks

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.host/HarvesterDisk.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/HarvesterDisk.vue
@@ -133,6 +133,14 @@ export default {
 
       return this.$store.getters[`${ inStore }/byId`](HCI.BLOCK_DEVICE, `${ LONGHORN_SYSTEM }/${ name }`) || {};
     },
+
+    isCorrupted() {
+      return this.blockDevice?.status?.deviceStatus?.fileSystem?.corrupted;
+    },
+
+    isFormatting() {
+      return this.blockDevice.isFormatting;
+    },
   },
   methods: {
     update() {
@@ -151,7 +159,12 @@ export default {
       :label="mountedMessage"
     />
     <Banner
-      v-if="isFormatted"
+      v-if="isFormatting"
+      color="info"
+      :label="t('harvester.host.disk.fileSystem.formatting')"
+    />
+    <Banner
+      v-else-if="isFormatted && !isCorrupted"
       color="info"
       :label="formattedBannerLabel"
     />
@@ -221,7 +234,7 @@ export default {
         />
       </div>
     </div>
-    <div v-if="value.isNew && !isFormatted" class="row mt-10">
+    <div v-if="(value.isNew && !isFormatted) || isCorrupted" class="row mt-10">
       <div class="col span-6">
         <RadioGroup
           v-model="value.forceFormatted"

--- a/pkg/harvester/edit/harvesterhci.io.host/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/index.vue
@@ -81,6 +81,8 @@ export default {
       return provisioned && isCurrentNode && !isLonghornMounted;
     })
       .map((d) => {
+        const corrupted = d?.status?.deviceStatus?.fileSystem?.corrupted;
+
         return {
           isNew:          true,
           name:           d?.metadata?.name,
@@ -88,7 +90,7 @@ export default {
           path:           d?.spec?.fileSystem?.mountPoint,
           blockDevice:    d,
           displayName:    d?.displayName,
-          forceFormatted: d?.spec?.fileSystem?.forceFormatted || false,
+          forceFormatted: corrupted ? true : d?.spec?.fileSystem?.forceFormatted || false,
         };
       });
 

--- a/pkg/harvester/formatters/HarvesterDiskState.vue
+++ b/pkg/harvester/formatters/HarvesterDiskState.vue
@@ -53,7 +53,7 @@ export default {
     },
 
     warningMessage() {
-      const blockDevices = this.row?.blockDevices || [];
+      const blockDevices = this.row?.unProvisionedDisks || [];
 
       const out = [];
 

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -398,6 +398,7 @@ harvester:
       error: Host has unready or unschedulable disks.
       fileSystem:
         info: Current file system is {system}, You can format it manually.
+        formatting: Disk is formatting, please wait.
       tags:
         label: Disk Tags
         addLabel: Add Disk Tag

--- a/pkg/harvester/models/harvesterhci.io.blockdevice.js
+++ b/pkg/harvester/models/harvesterhci.io.blockdevice.js
@@ -52,4 +52,11 @@ export default class HciBlockDevice extends HarvesterResource {
   get displayName() {
     return this.status?.deviceStatus?.devPath || this?.metadata?.name;
   }
+
+  get isFormatting() {
+    const conditions = this?.status?.conditions || [];
+    const formatting = conditions.find(c => c.type === 'Formatting') || {};
+
+    return formatting.status === 'True';
+  }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
~- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:~
~- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:~
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Vicente-Cheng 

Should give a chance to force format or fsck for the corrupted additional disks
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/4016

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Allow force format when the disk is corrupted
- Add a banner when the disk is formatting
- Fix disk state

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

1. Add a disk(e.g. /dev/sda) and then remove it by UI
2. Make the disk corrupted (`dd if=/dev/zero of=/dev/sda bs=512k count=1 oflag=sync`)
3. Add the disk again

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/harvester/dashboard/assets/18737885/2196cda0-2c5a-47a9-ba01-cd633e7c819f)
