### PR TITLE
HARVESTER: refactor vnc shortcut keys

### DIFF
--- a/pkg/harvester/components/novnc/NovncConsoleCustomKeys.vue
+++ b/pkg/harvester/components/novnc/NovncConsoleCustomKeys.vue
@@ -1,0 +1,245 @@
+<script>
+import { STEVE } from '@shell/config/types';
+import Banner from '@components/Banner/Banner.vue';
+import AsyncButton from '@shell/components/AsyncButton';
+import ModalWithCard from '@shell/components/ModalWithCard';
+
+const PREFERED_SHORTCUT_KEYS = 'prefered-shortcut-keys';
+
+export default {
+  components: {
+    ModalWithCard, Banner, AsyncButton
+  },
+
+  data() {
+    return {
+      keysRecord:            [],
+      addedShortcutKeys:     [],
+      preferredShortcutKeys: [],
+      isRecording:           false,
+    };
+  },
+
+  computed: {
+    savedShortcutKeys() {
+      const preference = this.$store.getters['management/all'](STEVE.PREFERENCE);
+      const preferedShortcutKeys = preference?.[0]?.data?.[PREFERED_SHORTCUT_KEYS];
+      let out = [];
+
+      if (!preferedShortcutKeys) {
+        return out;
+      }
+
+      try {
+        out = JSON.parse(preferedShortcutKeys);
+      } catch (err) {
+        this.$store.dispatch('growl/fromError', {
+          title: this.t('generic.notification.title.error', { name: this.t('harvester.virtualMachine.detail.console.customShortcutKeys') }),
+          err,
+        }, { root: true });
+      }
+
+      return out;
+    },
+
+    displayedKeys() {
+      const out = this.addedShortcutKeys.concat(this.preferredShortcutKeys).map((item) => {
+        const out = item.map(K => ` <code>${ K.key.charAt(0).toUpperCase() + K.key.slice(1) }</code>`);
+
+        return out.join(',');
+      });
+
+      return out;
+    },
+
+    recordButton() {
+      if (this.isRecording) {
+        return 'harvester.virtualMachine.detail.console.record.stop';
+      }
+
+      return 'harvester.virtualMachine.detail.console.record.start';
+    },
+
+    keysRecordFormat() {
+      if (!this.isRecording && this.keysRecord.length === 0) {
+        return this.t('harvester.virtualMachine.detail.console.record.tips');
+      }
+
+      const out = this.keysRecord.map(item => ` <code>${ item.key.charAt(0).toUpperCase() + item.key.slice(1) }</code>`);
+
+      return `Keys: ${ out.join(',') }`;
+    },
+
+    canAdd() {
+      const hasRecord = this.keysRecord.length > 0;
+      let validationList = [].concat(this.preferredShortcutKeys, this.addedShortcutKeys);
+
+      if (!hasRecord) {
+        return false;
+      }
+
+      validationList.push(this.keysRecord);
+
+      validationList = validationList.map((item) => {
+        const out = item.map(K => K.key);
+
+        return out.join(',');
+      });
+
+      return validationList.length === new Set(validationList).size;
+    },
+  },
+
+  watch: {
+    savedShortcutKeys: {
+      handler() {
+        this.preferredShortcutKeys = [].concat(this.savedShortcutKeys) || [];
+      },
+      immediate: true
+    },
+  },
+
+  methods: {
+    show() {
+      this.$refs.recordShortcutKeys.open();
+    },
+
+    closeRecordingModal() {
+      window.removeEventListener('keydown', this.handleShortcut);
+      this.$emit('close');
+    },
+
+    toggleRecording() {
+      this.isRecording = !this.isRecording;
+
+      if (this.isRecording) {
+        this.keysRecord = [];
+        window.addEventListener('keydown', this.handleShortcut);
+      } else {
+        window.removeEventListener('keydown', this.handleShortcut);
+      }
+    },
+
+    handleShortcut(event) {
+      event.preventDefault();
+
+      const {
+        key, keyCode, code, location, charCode
+      } = event;
+
+      this.keysRecord.push({
+        key, keyCode, code, location, charCode
+      });
+    },
+
+    addShortcutKey() {
+      this.addedShortcutKeys.push([].concat(this.keysRecord));
+    },
+
+    removeKey(keys) {
+      const key = keys.replace(/(\s*)<code>|<\/code>/g, '').replace(/\s*,\s*/g, ',');
+
+      this.addedShortcutKeys = this.addedShortcutKeys.filter((item) => {
+        const formatkey = item.map(K => K.key.charAt(0).toUpperCase() + K.key.slice(1)).join(',');
+
+        return formatkey !== key;
+      });
+
+      this.preferredShortcutKeys = this.preferredShortcutKeys.filter((item) => {
+        const formatkey = item.map(K => K.key.charAt(0).toUpperCase() + K.key.slice(1)).join(',');
+
+        return formatkey !== key;
+      });
+    },
+
+    async saveKeys(buttonCb) {
+      const out = [].concat(this.preferredShortcutKeys, this.addedShortcutKeys);
+      const preference = this.$store.getters['management/all'](STEVE.PREFERENCE)?.[0];
+
+      try {
+        this.$set(preference.data, PREFERED_SHORTCUT_KEYS, JSON.stringify(out));
+        await preference.save();
+        this.closeRecordingModal();
+        buttonCb(true);
+      } catch (err) {
+        buttonCb(false);
+      }
+    },
+  }
+};
+</script>
+
+<template>
+  <ModalWithCard ref="recordShortcutKeys" name="recordShortcutKeys" :width="550">
+    <template #title>
+      <t k="harvester.virtualMachine.detail.console.customShortcutKeys" />
+    </template>
+
+    <template #content>
+      <div class="row">
+        <div class="col span-12">
+          <Banner color="info">
+            <span v-clean-html="keysRecordFormat"></span>
+          </Banner>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-12">
+          <button class="btn bg-primary" @click="toggleRecording">
+            <t :k="recordButton" />
+            <i class="icon icon-fw" :class="isRecording ? 'icon-dot-open' : 'icon-dot'" />
+          </button>
+          <button :disabled="!canAdd" class="btn bg-primary" @click="addShortcutKey">
+            <t k="generic.add" />
+          </button>
+        </div>
+      </div>
+
+      <hr>
+
+      <div class="displayed-keys mt-20">
+        <h4
+          v-clean-html="t('harvester.virtualMachine.detail.console.record.preferredKeys')"
+          class="text-default-text"
+        />
+
+        <div class="displayed-banners">
+          <Banner v-for="(keys,index) in displayedKeys" :key="index" color="info" :closable="true" @close="removeKey(keys)">
+            <span v-clean-html="keys"></span>
+          </Banner>
+        </div>
+      </div>
+    </template>
+
+    <template #footer>
+      <div class="actions">
+        <button class="btn role-secondary mr-20" @click.prevent="closeRecordingModal">
+          <t k="generic.close" />
+        </button>
+        <AsyncButton
+          mode="done"
+          @click="saveKeys"
+        />
+      </div>
+    </template>
+  </ModalWithCard>
+</template>
+
+<style lang="scss" scoped>
+  .displayed-keys {
+    .banner {
+      margin: 0;
+    }
+  }
+
+  .displayed-banners {
+    max-height: 155px;
+    overflow: auto;
+  }
+
+  .actions {
+    width: 100%;
+    display: flex;
+    justify-content: end;
+  }
+</style>

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -619,7 +619,16 @@ harvester:
         down: No events in the past hour
       console:
         down: This Virtual Machine is down. Please start it to access its console.
-        shortKeys: Shortcut Keys
+        shortcutKeys: Shortcut Keys
+        customShortcutKeys: Custom Shortcut Keys
+        management: Management Shortcut Keys
+        record:
+          start: Record
+          recording: Recording
+          stop: Stop Recording
+          tips: Pressing the record button will capture your keyboard inputs.
+          send: Send
+          preferredKeys: Preferred Custom Shortcut Keys
     terminationGracePeriodSeconds:
       label: Termination Grace Period
     affinity:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- ~Is this a multi-tenancy feature/bug?~
    - [ ] ~Yes, the relevant RBAC changes are at:~
- ~Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?~
    - [ ] ~Yes, the relevant PR is at:~
- ~Are backend engineers aware of UI changes?~
	- [ ] ~Yes, the backend owner is:~


<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/3989

upstream PR:

https://github.com/rancher/dashboard/pull/9151

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

1. Go to rancher cluster and then import existing harvester cluster with different roles(like project owner/member and cluster owner/member
2. Use different roles to login and create themselves vm
3. Go to open web vnc window
4. Manage themselves custom shortcut keys
5. The custom shortcut keys is working correctly.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/harvester/dashboard/assets/15041915/c133efdf-020e-470a-80b0-e9d9bc8512ec)
![image](https://github.com/harvester/dashboard/assets/15041915/fd7d8491-fbc2-4387-8188-32556b97d863)
