### PR TITLE
HARVESTER: fix project-namespace display

### DIFF
--- a/pkg/harvester/config/harvester.js
+++ b/pkg/harvester/config/harvester.js
@@ -237,7 +237,7 @@ export function init($plugin, store) {
 
   basicType(['projects-namespaces']);
   virtualType({
-    ifHave:     IF_HAVE.NOT_STANDALONE_HARVESTER,
+    ifHave:     IF_HAVE.MULTI_CLUSTER,
     labelKey:   'harvester.projectNamespace.label',
     group:      'root',
     namespaced: true,
@@ -260,8 +260,7 @@ export function init($plugin, store) {
         name:   `${ PRODUCT_NAME }-c-cluster-resource`,
         params: { resource: NAMESPACE }
       },
-      exact:  false,
-      ifHave: IF_HAVE.MCM_DISABLED,
+      exact: false,
     });
   }
 

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -13,6 +13,10 @@ nav:
     Logging: Logging
     'Monitoring & Logging': Monitoring & Logging
 
+members:
+  clusterMemebership: Cluster Membership
+  projectMembership: Project Membership
+
 asyncButton:
   restart:
     action: Save & Restart

--- a/pkg/harvester/l10n/zh-hans.yaml
+++ b/pkg/harvester/l10n/zh-hans.yaml
@@ -12,6 +12,9 @@ nav:
     Monitoring: 监控
     Logging: 日志
     'Monitoring & Logging': 监控 & 日志
+members:
+  clusterMemebership: 集群成员
+  projectMembership: 项目成员
 
 asyncButton:
   restart:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The cluster type remains the same as before, we will remove `rancher-mamage-support` from the setting, and the back end will create an external rancher through `addon` to import the harvester cluster.

#### PR Checklist
~- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:~
~- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:~
~- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:~

Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->