### PR TITLE
HARVESTER: Fix Load Balancer creation with Health Check creates data-type unmarshalling error

### DIFF
--- a/pkg/harvester/edit/loadbalancer.harvesterhci.io.loadbalancer/HealthCheck.vue
+++ b/pkg/harvester/edit/loadbalancer.harvesterhci.io.loadbalancer/HealthCheck.vue
@@ -74,7 +74,7 @@ export default {
         </div>
         <div class="col span-6">
           <LabeledInput
-            v-model="value.successThreshold"
+            v-model.number="value.successThreshold"
             :mode="mode"
             type="number"
             :label="t('harvester.service.healthCheckSuccessThreshold.label')"
@@ -86,7 +86,7 @@ export default {
       <div class="row mt-10">
         <div class="col span-6">
           <LabeledInput
-            v-model="value.failureThreshold"
+            v-model.number="value.failureThreshold"
             :mode="mode"
             type="number"
             :label="t('harvester.service.healthCheckFailureThreshold.label')"
@@ -96,7 +96,7 @@ export default {
         </div>
         <div class="col span-6">
           <LabeledInput
-            v-model="value.periodSeconds"
+            v-model.number="value.periodSeconds"
             :mode="mode"
             type="number"
             :label="t('harvester.service.healthCheckPeriod.label')"
@@ -107,7 +107,7 @@ export default {
       <div class="row mt-10">
         <div class="col span-6">
           <LabeledInput
-            v-model="value.timeoutSeconds"
+            v-model.number="value.timeoutSeconds"
             :mode="mode"
             type="number"
             :label="t('harvester.service.healthCheckTimeout.label')"

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1121,7 +1121,7 @@ harvester:
   ipPool:
     label: IP Pools
     network:
-      label: Network
+      label: VM Network
     tabs:
       range: Range
       scope: Scope

--- a/pkg/harvester/l10n/zh-hans.yaml
+++ b/pkg/harvester/l10n/zh-hans.yaml
@@ -1120,7 +1120,7 @@ harvester:
   ipPool:
     label: IP 池
     network:
-      label: 网络
+      label: 虚拟机网络
     tabs:
       range: 范围
       scope: 范围


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
~- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:~
~- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:~
~- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:~

- Fix Load Balancer creation with Health Check creates data-type unmarshalling error
- Change IP pool network label
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/4135
- https://github.com/harvester/harvester/issues/1458#issuecomment-1608063654

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/harvester/dashboard/assets/18737885/5ac6c624-1a77-44e4-9b95-24c0f5049be1)
