### PR TITLE
HARVESTER: fix podAffinity can not update match expressions

### DIFF
--- a/shell/components/form/PodAffinity.vue
+++ b/shell/components/form/PodAffinity.vue
@@ -348,6 +348,11 @@ export default {
       this.queueUpdate();
     },
 
+    updateLabelSelector(e, props) {
+      this.set(props.row.value, 'labelSelector.matchExpressions', e);
+      this.queueUpdate();
+    },
+
     isEmpty,
     get,
     set
@@ -439,7 +444,7 @@ export default {
             :value="get(props.row.value, 'labelSelector.matchExpressions')"
             :show-remove="false"
             :data-testid="`pod-affinity-expressions-index${props.i}`"
-            @input="e=>set(props.row.value, 'labelSelector.matchExpressions', e)"
+            @input="e=>updateLabelSelector(e, props)"
           />
           <div class="row mt-20">
             <div class="col span-9">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Update match expressions manually.

**Related upstream PR**

- https://github.com/rancher/dashboard/pull/9238/files

#### PR Checklist
- ~Is this a multi-tenancy feature/bug?~
    - [ ] ~Yes, the relevant RBAC changes are at:~
- ~Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?~
    - [ ] ~Yes, the relevant PR is at:~
- ~Are backend engineers aware of UI changes?~
	- [ ] ~Yes, the backend owner is:~


<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/2317#issuecomment-1607255344

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->