### PR TITLE
HARVESTER: fix efi checked

### DIFF
--- a/pkg/harvester/mixins/harvester-vm/impl.js
+++ b/pkg/harvester/mixins/harvester-vm/impl.js
@@ -132,7 +132,7 @@ export default {
     },
 
     isEfiEnabled(spec) {
-      return !!(spec?.template?.spec?.domain?.features?.smm && spec?.template?.spec?.domain?.firmware?.bootloader?.efi);
+      return !!(spec?.template?.spec?.domain?.firmware?.bootloader?.efi);
     },
 
     isTpmEnabled(spec) {

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -1314,7 +1314,16 @@ export default {
         set(this.spec.template.spec.domain, 'features.smm.enabled', true);
         set(this.spec.template.spec.domain, 'firmware.bootloader.efi.secureBoot', true);
       } else if (boot.efi && !boot.secureBoot) {
-        set(this.spec.template.spec.domain, 'features.smm.enabled', false);
+        // set(this.spec.template.spec.domain, 'features.smm.enabled', false);
+
+        try {
+          this.$delete(this.spec.template.spec.domain.features.smm, 'enabled');
+          const noKeys = Object.keys(this.spec.template.spec.domain.features.smm).length === 0;
+
+          if (noKeys) {
+            this.$delete(this.spec.template.spec.domain.features, 'smm');
+          }
+        } catch (e) {}
         set(this.spec.template.spec.domain, 'firmware.bootloader.efi.secureBoot', false);
       } else {
         this.$delete(this.spec.template.spec.domain, 'firmware');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
When only `Booting in EFI mode` is selected, we do not need to pass the `smm` parameter.

#### PR Checklist
~- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:~
~- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:~
~- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:~

Fixes #
<!-- Define findings related to the feature or bug issue. -->
- https://github.com/harvester/harvester/issues/4145

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->