### PR TITLE
HARVESTER: improve exhibition of addon's status

### DIFF
--- a/pkg/harvester/models/harvesterhci.io.addon.js
+++ b/pkg/harvester/models/harvesterhci.io.addon.js
@@ -16,9 +16,19 @@ export default class HciAddonConfig extends HarvesterResource {
     ];
   }
 
-  toggleAddon() {
-    this.spec.enabled = !this.spec.enabled;
-    this.save();
+  async toggleAddon() {
+    const enableHistory = this.spec.enabled;
+
+    try {
+      this.spec.enabled = !this.spec.enabled;
+      await this.save();
+    } catch (err) {
+      this.spec.enabled = enableHistory;
+      this.$dispatch('growl/fromError', {
+        title: this.t('generic.notification.title.error', { name: (this.metadata.name) }),
+        err,
+      }, { root: true });
+    }
   }
 
   get stateColor() {
@@ -28,7 +38,7 @@ export default class HciAddonConfig extends HarvesterResource {
       return 'text-success';
     } else if (state === 'Disabled') {
       return 'text-darker';
-    } else if (state === 'Processing') {
+    } else if (state?.toLowerCase().includes('ing')) {
       return 'text-info';
     } else if (state?.toLowerCase().includes('failed') || state?.toLowerCase().includes('error')) {
       return 'text-error';
@@ -38,17 +48,23 @@ export default class HciAddonConfig extends HarvesterResource {
   }
 
   get stateDisplay() {
-    if (!this?.status?.status) {
-      return this.spec.enabled === false ? 'Disabled' : 'Processing';
-    }
-
     const out = this?.status?.status;
+
+    if (!out) {
+      return 'Disabled';
+    }
 
     if (out.startsWith('Addon')) {
       return out.replace('Addon', '');
     }
 
     return out;
+  }
+
+  get stateDescription() {
+    const failedCondition = (this.status?.conditions || []).find(C => C.type === 'Failed');
+
+    return failedCondition?.message || super.stateDescription;
   }
 
   get displayName() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- ~Is this a multi-tenancy feature/bug?~
    - [ ] ~Yes, the relevant RBAC changes are at:~
- ~Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?~
    - [ ] ~Yes, the relevant PR is at:~
- ~Are backend engineers aware of UI changes?~
	- [ ] ~Yes, the backend owner is:~


### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

We want to improve the exhibitions of addon's status.

- https://github.com/harvester/harvester/issues/4067

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

1. Swtich enabling/disabling status of addon quickly should be failed and you should see the error message on the top-right corner.
2. When enabling/disabling/updating if you edit the configurations of addon and then save, save should be failed and the error message should be also displayed.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![image](https://github.com/harvester/dashboard/assets/15041915/41c130ff-a556-4212-9c58-f7e6b995bc07)

![image](https://github.com/harvester/dashboard/assets/15041915/faabacfd-b2e3-4e18-affe-9999d43e3a04)
