### PR TITLE
fix toggle button can't click

### DIFF
--- a/pkg/harvester/components/SettingList.vue
+++ b/pkg/harvester/components/SettingList.vue
@@ -67,7 +67,7 @@ export default {
     },
 
     toggleHide(s) {
-      this.settings.find((setting) => {
+      this.categorySettings.find((setting) => {
         if (setting.id === s.id) {
           setting.hide = !setting.hide;
         }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

https://github.com/harvester/dashboard/assets/24985926/7faa6d20-99be-43f8-8a7d-450b9ac6dd82


setting page hide and show buttons are not clickable。

reproduce step:
1. Configure backup-target, click Save
2. Click on any show or hide button on the setting page.

#### PR Checklist
~- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:~
~- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:~
~- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:~

Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
When the websocket is updated, the `settings` object and the `categorySettings` object are completely unrelated, so changing the value of `this.settings` will not affect the value of categorySettings.




### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->