### PR TITLE
[DeviceList]: make input `rows` reactive.

### DIFF
--- a/pkg/harvester/dialog/EnablePassthrough.vue
+++ b/pkg/harvester/dialog/EnablePassthrough.vue
@@ -38,7 +38,9 @@ export default {
 
       // if this is imported Harvester, there may be users other than 'admin
       if (!isSingleProduct) {
-        userName = this.$store.getters['auth/v3User']?.username;
+        const user = this.$store.getters['auth/v3User'];
+
+        userName = user?.username || user?.id;
       }
 
       for (let i = 0; i < this.resources.length; i++) {

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
@@ -17,7 +17,7 @@ export default {
       required: true,
     },
 
-    rows: {
+    devices: {
       type:     Array,
       required: true,
     },
@@ -83,9 +83,17 @@ export default {
 
     return {
       headers,
+      rows:        [],
       parentSriov: null,
       filterRows:  []
     };
+  },
+
+  watch: {
+    devices(v) {
+      this.rows = v;
+      this.filterRows = this.rows;
+    }
   },
 
   methods: {

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
@@ -134,7 +134,14 @@ export default {
 </script>
 
 <template>
-  <ResourceTable :headers="headers" :schema="schema" :rows="filterRows" :use-query-params-for-simple-filtering="true" :sort-generation-fn="sortGenerationFn">
+  <ResourceTable
+    :headers="headers"
+    :schema="schema"
+    :rows="filterRows"
+    :use-query-params-for-simple-filtering="true"
+    :sort-generation-fn="sortGenerationFn"
+    :rows-per-page="10"
+  >
     <template #group-by="{group}">
       <div :ref="group.key" v-trim-whitespace class="group-tab">
         <button v-if="groupIsAllEnabled(group.rows)" type="button" class="btn btn-sm role-secondary mr-5" @click="e=>{disableGroup(group.rows); e.target.blur()}">

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
@@ -90,9 +90,12 @@ export default {
   },
 
   watch: {
-    devices(v) {
-      this.rows = v;
-      this.filterRows = this.rows;
+    devices: {
+      handler(v) {
+        this.rows = v;
+        this.filterRows = this.rows;
+      },
+      immediate: true,
     }
   },
 

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/index.vue
@@ -261,7 +261,7 @@ export default {
       </template>
       <div class="row mt-20">
         <div class="col span-12">
-          <DeviceList :schema="pciDeviceSchema" :rows="pciDevices" @submit.prevent />
+          <DeviceList :schema="pciDeviceSchema" :devices="pciDevices" @submit.prevent />
         </div>
       </div>
     </div>

--- a/pkg/harvester/list/devices.harvesterhci.io.pcidevice.vue
+++ b/pkg/harvester/list/devices.harvesterhci.io.pcidevice.vue
@@ -80,7 +80,7 @@ export default {
       {{ t('harvester.pci.noPCIPermission') }}
     </Banner>
   </div>
-  <DeviceList v-else-if="hasSchema && enabledPCI" :rows="rows" :schema="schema" />
+  <DeviceList v-else-if="hasSchema && enabledPCI" :devices="rows" :schema="schema" />
   <div v-else>
     <Banner color="warning">
       <MessageLink

--- a/pkg/harvester/models/devices.harvesterhci.io.pcidevice.js
+++ b/pkg/harvester/models/devices.harvesterhci.io.pcidevice.js
@@ -90,7 +90,9 @@ export default class PCIDevice extends SteveModel {
 
     // if this is imported Harvester, there may be users other than admin
     if (!isSingleProduct) {
-      userName = this.$rootGetters['auth/v3User']?.username;
+      const user = this.$rootGetters['auth/v3User'];
+
+      userName = user?.username || user?.id;
     }
 
     return this.claimedBy === userName;

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -149,7 +149,12 @@ export default {
     forceUpdateLiveAndDelayed: {
       type:    Number,
       default: 0
-    }
+    },
+
+    rowsPerPage: {
+      type:    Number,
+      default: null, // Default comes from the user preference
+    },
   },
 
   mounted() {
@@ -441,6 +446,7 @@ export default {
     :paging="true"
     :paging-params="pagingParams"
     :paging-label="pagingLabel"
+    :rows-per-page="rowsPerPage"
     :row-actions="rowActions"
     :table-actions="_showBulkActions"
     :overflow-x="overflowX"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Fixes https://github.com/harvester/harvester/issues/4796
<!-- Define findings related to the feature or bug issue. -->

### Technical notes

The `rows` input field is replaced by `devices` to allow the list of devices to be reactive for component `DeviceList`.
In addition, I changed the `rowsPerPage` values to 10, since the device table is huge in this case (> 150 elements) and it's very difficult to manage inside the VM form, See screenshots.

### Screenshot/Video

List of devices:
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![image](https://github.com/harvester/dashboard/assets/26394656/da14e6bc-9e70-48b6-a2d3-945408bc068c)

Pagination of 10 rows per page:

![image](https://github.com/harvester/dashboard/assets/26394656/a07b90e6-b6b9-41aa-a592-5e71903fe076)

