### PR TITLE
Replace `vue.extend` with `defineComponent` in Harvester

### DIFF
--- a/pkg/harvester/pages/c/_cluster/projectsnamespaces.vue
+++ b/pkg/harvester/pages/c/_cluster/projectsnamespaces.vue
@@ -1,14 +1,10 @@
 <script lang="ts">
-import Vue from 'vue';
-import { Location } from 'vue-router';
+import { defineComponent } from 'vue';
 import ExplorerProjectsNamespaces from '@shell/components/ExplorerProjectsNamespaces.vue';
 import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../../config/harvester';
 import { MANAGEMENT, NAMESPACE } from '@shell/config/types';
-interface Data {
-  createProjectLocation: Location,
-  createNamespaceLocation: Location
-}
-export default Vue.extend<Data, any, any, any>({
+
+export default defineComponent({
   components: { ExplorerProjectsNamespaces },
   data() {
     return {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
contributes to rancher/dashboard#10104

This replaces the usage of `Vue.extend` with `defineComponent` in Harvester. `defineComponent` provides better type inference, improved TypeScript support, and will be the recommended way to define components when Dashboard migrates to Vue 3.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Replaced instances of `Vue.extend` with `defineComponent` for components located under `pkg/harvester`
- Refactored code as necessary to maintain to take advantage of the better TypeScript support

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

This has a broad reach across dashboard. Ideally, we will want to test multiple cases where the following components have been altered:

- projectsnamespaces.vue