### PR TITLE
Support network interface boot orders in VM forms

### DIFF
--- a/pkg/harvester/components/BootOrder.vue
+++ b/pkg/harvester/components/BootOrder.vue
@@ -1,0 +1,66 @@
+<script>
+import { _VIEW } from '@shell/config/query-params';
+
+export default {
+  name: 'BootOrder',
+
+  props: {
+    value: {
+      type:     Array,
+      required: true,
+    },
+
+    index: {
+      type:     Number,
+      required: true,
+    },
+
+    mode: {
+      type:     String,
+      required: true
+    },
+  },
+
+  computed: {
+    isView() {
+      return this.mode === _VIEW;
+    },
+  },
+
+  methods: {
+    changeSort(idx, type) {
+      // true: down, false: up
+      this.value.splice(type ? idx : idx - 1, 1, ...this.value.splice(type ? idx + 1 : idx, 1, this.value[type ? idx : idx - 1]));
+      this.update();
+    },
+    update() {
+      this.$emit('input', this.value);
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="boot-order">
+    <div v-if="!isView" class="buttons-container mr-15">
+      <button :disabled="index === 0" class="btn btn-sm role-primary" @click.prevent="changeSort(index, false)">
+        <i class="icon icon-lg icon-chevron-up"></i>
+      </button>
+
+      <button :disabled="index === value.length - 1" class="btn btn-sm role-primary" @click.prevent="changeSort(index, true)">
+        <i class="icon icon-lg icon-chevron-down"></i>
+      </button>
+    </div>
+
+    <div class="text-muted">
+      bootOrder: {{ index + 1 }}
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .boot-order {
+    display: flex;
+    align-items: center;
+  }
+</style>

--- a/pkg/harvester/components/BootOrder.vue
+++ b/pkg/harvester/components/BootOrder.vue
@@ -5,20 +5,25 @@ export default {
   name: 'BootOrder',
 
   props: {
-    value: {
-      type:     Array,
-      required: true,
+    index: {
+      type:    Number,
+      default: 0,
     },
 
-    index: {
-      type:     Number,
-      required: true,
+    count: {
+      type:    Number,
+      default: 1,
     },
 
     mode: {
       type:     String,
       required: true
     },
+
+    tooltip: {
+      type:    Object,
+      default: null
+    }
   },
 
   computed: {
@@ -28,13 +33,8 @@ export default {
   },
 
   methods: {
-    changeSort(idx, type) {
-      // true: down, false: up
-      this.value.splice(type ? idx : idx - 1, 1, ...this.value.splice(type ? idx + 1 : idx, 1, this.value[type ? idx : idx - 1]));
-      this.update();
-    },
-    update() {
-      this.$emit('input', this.value);
+    update(step) {
+      this.$emit('input', step);
     }
   }
 };
@@ -43,16 +43,19 @@ export default {
 <template>
   <div class="boot-order">
     <div v-if="!isView" class="buttons-container mr-15">
-      <button :disabled="index === 0" class="btn btn-sm role-primary" @click.prevent="changeSort(index, false)">
+      <button :disabled="index === 0" class="btn btn-sm role-primary" @click.prevent="update(-1)">
         <i class="icon icon-lg icon-chevron-up"></i>
       </button>
 
-      <button :disabled="index === value.length - 1" class="btn btn-sm role-primary" @click.prevent="changeSort(index, true)">
+      <button :disabled="index === count - 1" class="btn btn-sm role-primary" @click.prevent="update(1)">
         <i class="icon icon-lg icon-chevron-down"></i>
       </button>
     </div>
 
-    <div class="text-muted">
+    <div
+      v-clean-tooltip="tooltip"
+      class="text-muted"
+    >
       bootOrder: {{ index + 1 }}
     </div>
   </div>

--- a/pkg/harvester/detail/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/detail/kubevirt.io.virtualmachine/index.vue
@@ -168,11 +168,16 @@ export default {
           :namespace="value.metadata.namespace"
           :vm="value"
           :resource-type="value.type"
+          :boot-orders="bootOrders"
         />
       </Tab>
 
       <Tab name="networks" :label="t('harvester.virtualMachine.detail.tabs.networks')" class="bordered-table" :weight="5">
-        <Network v-model="networkRows" mode="view" />
+        <Network
+          v-model="networkRows"
+          :boot-orders="bootOrders"
+          mode="view"
+        />
       </Tab>
 
       <Tab name="keypairs" :label="t('harvester.virtualMachine.detail.tabs.keypairs')" class="bordered-table" :weight="3">

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineDeviceBootOrder.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineDeviceBootOrder.vue
@@ -1,0 +1,88 @@
+<script>
+import { _VIEW } from '@shell/config/query-params';
+import BootOrder from '../../components/BootOrder';
+
+export default {
+  name: 'VirtualMachineDeviceBootOrder',
+
+  components: { BootOrder },
+
+  props: {
+    bootOrders: {
+      type:    Array,
+      default: () => {
+        return [];
+      }
+    },
+
+    bootOrder: {
+      type:    Number,
+      default: null,
+    },
+
+    mode: {
+      type:     String,
+      required: true
+    },
+  },
+
+  computed: {
+    isView() {
+      return this.mode === _VIEW;
+    },
+    index() {
+      return this.bootOrder !== null ? this.bootOrder - 1 : 0;
+    },
+    count() {
+      return Math.max(...this.bootOrders.map(o => o.bootOrder));
+    },
+    tooltipContent() {
+      if (this.bootOrders.length === 0) {
+        return '';
+      }
+
+      const title = this.t('harvester.virtualMachine.bootOrder.details');
+
+      const bootOrders = this.bootOrders.sort((a, b) => a.bootOrder || 0 - b.bootOrder || 0);
+
+      return [
+        ...bootOrders
+          .filter(f => f.type === 'disk')
+          .reduce((acc, x) => `${ acc } &nbsp&nbsp&nbsp${ x.name }:  <b>${ x.bootOrder }</b><br>`, 'Disks:<br>'),
+        ...bootOrders
+          .filter(f => f.type === 'interface')
+          .reduce((acc, x) => `${ acc } &nbsp&nbsp&nbsp${ x.name }:  <b>${ x.bootOrder }</b><br>`, 'Networks:<br>')
+      ].reduce((acc, r) => `${ acc }${ r }`, `${ title }&nbsp&nbsp&nbsp<br><br>`) || '';
+    },
+  },
+
+  methods: {
+    onInputIndex(step) {
+      const elem = this.bootOrders.find(o => o.bootOrder === this.bootOrder);
+
+      let neu = this.index + step + 1;
+
+      while (!this.bootOrders.find(o => o.bootOrder === neu)) {
+        neu = neu + step;
+      }
+
+      const emit = {
+        ...elem,
+        neu,
+      };
+
+      this.$emit('input', emit);
+    }
+  }
+};
+</script>
+
+<template>
+  <BootOrder
+    :index="index"
+    :count="count"
+    :mode="mode"
+    :tooltip="{content: tooltipContent, placement: 'right'}"
+    @input="onInputIndex"
+  />
+</template>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineDeviceBootOrder.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineDeviceBootOrder.vue
@@ -41,18 +41,10 @@ export default {
         return '';
       }
 
+      const bootOrders = [...this.bootOrders].sort((a, b) => a.bootOrder - b.bootOrder);
       const title = this.t('harvester.virtualMachine.bootOrder.details');
 
-      const bootOrders = this.bootOrders.sort((a, b) => a.bootOrder || 0 - b.bootOrder || 0);
-
-      return [
-        ...bootOrders
-          .filter(f => f.type === 'disk')
-          .reduce((acc, x) => `${ acc } &nbsp&nbsp&nbsp${ x.name }:  <b>${ x.bootOrder }</b><br>`, 'Disks:<br>'),
-        ...bootOrders
-          .filter(f => f.type === 'interface')
-          .reduce((acc, x) => `${ acc } &nbsp&nbsp&nbsp${ x.name }:  <b>${ x.bootOrder }</b><br>`, 'Networks:<br>')
-      ].reduce((acc, r) => `${ acc }${ r }`, `${ title }&nbsp&nbsp&nbsp<br><br>`) || '';
+      return bootOrders.reduce((acc, r) => `${ acc } <b>${ r.bootOrder }</b>:  ${ r.type === 'disk' ? 'disk' : 'network' } / ${ r.name }<br>`, `${ title }<br><br>`);
     },
   },
 

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineNetwork/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineNetwork/index.vue
@@ -9,9 +9,14 @@ import { clone } from '@shell/utils/object';
 import { randomStr } from '@shell/utils/string';
 import { removeObject } from '@shell/utils/array';
 import { _VIEW } from '@shell/config/query-params';
+import BootOrder from '../../../components/BootOrder';
 
 export default {
-  components: { InfoBox, Base },
+  components: {
+    InfoBox,
+    Base,
+    BootOrder,
+  },
 
   props: {
     mode: {
@@ -135,11 +140,18 @@ export default {
       <Base
         :key="rows[i].rowKeyId"
         v-model="rows[i]"
+        class="mb-20"
         :rows="rows"
         :mode="mode"
         :is-single="isSingle"
         :network-option="networkOption"
         @update="update"
+      />
+
+      <BootOrder
+        v-model="rows"
+        :index="i"
+        :mode="mode"
       />
     </InfoBox>
 

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/index.vue
@@ -7,6 +7,7 @@ import UnitInput from '@shell/components/form/UnitInput';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import ModalWithCard from '@shell/components/ModalWithCard';
+import BootOrder from '../../../components/BootOrder';
 
 import { PVC, STORAGE_CLASS } from '@shell/config/types';
 import { HCI } from '../../../types';
@@ -20,7 +21,7 @@ import { PLUGIN_DEVELOPER, DEV } from '@shell/store/prefs';
 
 export default {
   components: {
-    Banner, BadgeStateFormatter, draggable, InfoBox, LabeledInput, UnitInput, LabeledSelect, ModalWithCard
+    Banner, BadgeStateFormatter, BootOrder, draggable, InfoBox, LabeledInput, UnitInput, LabeledSelect, ModalWithCard
   },
 
   props: {
@@ -311,21 +312,11 @@ export default {
               />
             </div>
 
-            <div class="bootOrder">
-              <div v-if="!isView" class="mr-15">
-                <button :disabled="i === 0" class="btn btn-sm role-primary" @click.prevent="changeSort(i, false)">
-                  <i class="icon icon-lg icon-chevron-up"></i>
-                </button>
-
-                <button :disabled="i === rows.length -1" class="btn btn-sm role-primary" @click.prevent="changeSort(i, true)">
-                  <i class="icon icon-lg icon-chevron-down"></i>
-                </button>
-              </div>
-
-              <div class="text-muted">
-                bootOrder: {{ i + 1 }}
-              </div>
-            </div>
+            <BootOrder
+              v-model="rows"
+              :index="i"
+              :mode="mode"
+            />
 
             <Banner v-if="volume.volumeStatus && !isCreate" class="mt-15 volume-status" color="warning" :label="volume.volumeStatus" />
           </InfoBox>
@@ -403,11 +394,6 @@ export default {
     top: 10px;
     right: 10px;
     padding: 0px;
-  }
-
-  .bootOrder {
-    display: flex;
-    align-items: center;
   }
 
   .buttons {

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -534,11 +534,19 @@ export default {
           :resource-type="value.type"
           :vm="value"
           :validate-required="true"
+          :boot-orders="bootOrders"
+          @boot-order="updateBootOrders"
         />
       </Tab>
 
       <Tab name="Network" :label="t('harvester.tab.network')" :weight="-2">
-        <Network v-model="networkRows" :mode="mode" :is-single="isSingle" />
+        <Network
+          v-model="networkRows"
+          :mode="mode"
+          :is-single="isSingle"
+          :boot-orders="bootOrders"
+          @boot-order="updateBootOrders"
+        />
       </Tab>
 
       <Tab name="nodeScheduling" :label="t('workload.container.titles.nodeScheduling')" :weight="-3">

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -652,6 +652,8 @@ harvester:
         inNamespaces: "Workloads in these namespaces"
       namespaces:
         label: Namespaces
+    bootOrder:
+      details: Boot Orders
 
   volume:
     label: Volumes

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -653,7 +653,7 @@ harvester:
       namespaces:
         label: Namespaces
     bootOrder:
-      details: Boot Orders
+      details: Boot Order
 
   volume:
     label: Volumes

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -23,6 +23,11 @@ import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations
 import impl, { QGA_JSON, USB_TABLET } from './impl';
 import { uniq } from '@shell/utils/array';
 
+const BOOT_ORDER_TYPE = {
+  DISK:      'disk',
+  INTERFACE: 'interface'
+};
+
 export const MANAGEMENT_NETWORK = 'management Network';
 
 export const OS = [{
@@ -282,6 +287,18 @@ export default {
         topologyKeyPlaceholder: this.t('harvesterManager.affinity.topologyKey.placeholder')
       };
     },
+
+    bootOrders() {
+      const buildElem = type => el => ({
+        ...el,
+        type
+      });
+
+      return [
+        ...this.diskRows?.map(buildElem(BOOT_ORDER_TYPE.DISK)),
+        ...this.networkRows?.map(buildElem(BOOT_ORDER_TYPE.INTERFACE))
+      ];
+    }
   },
 
   async created() {
@@ -325,8 +342,13 @@ export default {
       const sshKey = this.getSSHFromAnnotation(spec) || [];
 
       const imageId = this.getRootImageId(vm) || '';
-      const diskRows = this.getDiskRows(vm);
-      const networkRows = this.getNetworkRows(vm, { fromTemplate, init });
+
+      const { disks, interfaces } = this.generateBootOrders(vm);
+
+      const diskRows = this.getDiskRows(vm, { bootOrders: disks });
+      const networkRows = this.getNetworkRows(vm, {
+        fromTemplate, init, bootOrders: interfaces
+      });
       const hasCreateVolumes = this.getHasCreatedVolumes(spec) || [];
 
       let { userData = undefined, networkData = undefined } = this.getCloudInitNoCloud(spec);
@@ -391,7 +413,7 @@ export default {
       this.refreshYamlEditor();
     },
 
-    getDiskRows(vm) {
+    getDiskRows(vm, config) {
       const namespace = vm.metadata.namespace;
       const _volumes = vm.spec.template.spec.volumes || [];
       const _disks = vm.spec.template.spec.domain.devices.disks || [];
@@ -402,6 +424,8 @@ export default {
       if (_disks.length === 0) {
         out.push({
           id:               randomStr(5),
+          index:            0,
+          bootOrder:        config?.bootOrders?.[0] || 1,
           source:           SOURCE_TYPE.IMAGE,
           name:             'disk-0',
           accessMode:       'ReadWriteMany',
@@ -477,8 +501,6 @@ export default {
 
           const bus = DISK?.disk?.bus || DISK?.cdrom?.bus;
 
-          const bootOrder = DISK?.bootOrder ? DISK?.bootOrder : index;
-
           const parseValue = parseSi(size);
 
           const formatSize = formatSi(parseValue, {
@@ -492,7 +514,8 @@ export default {
 
           return {
             id:         randomStr(5),
-            bootOrder,
+            index,
+            bootOrder:  config?.bootOrders?.[index] || index + 1,
             source,
             name:       DISK.name,
             realName,
@@ -531,12 +554,10 @@ export default {
 
         const isPod = !!network.pod;
 
-        const bootOrder = I?.bootOrder ?? index;
-
         return {
           ...I,
           index,
-          bootOrder,
+          bootOrder:   config.bootOrders?.[index] || index + 1,
           type,
           isPod,
           newCreateId: (fromTemplate || init) ? randomStr(10) : false,
@@ -584,7 +605,7 @@ export default {
       const diskNameLables = [];
       const volumeClaimTemplates = [];
 
-      disk.forEach( (R, index) => {
+      disk.forEach( (R) => {
         const prefixName = this.value.metadata?.name || '';
 
         let dataVolumeName = '';
@@ -597,7 +618,7 @@ export default {
           dataVolumeName = R.realName;
         }
 
-        const _disk = this.parseDisk(R, index);
+        const _disk = this.parseDisk(R);
         const _volume = this.parseVolume(R, dataVolumeName);
         const _dataVolumeTemplate = this.parseVolumeClaimTemplate(R, dataVolumeName);
 
@@ -754,9 +775,9 @@ export default {
       const networks = [];
       const interfaces = [];
 
-      networkRow.forEach( (R, index) => {
+      networkRow.forEach( (R) => {
         const _network = this.parseNetwork(R);
-        const _interface = this.parseInterface(R, index);
+        const _interface = this.parseInterface(R);
 
         networks.push(_network);
         interfaces.push(_interface);
@@ -872,16 +893,70 @@ export default {
       this.$set(this, 'memory', memory);
     },
 
-    parseDisk(R, index) {
-      const out = { name: R.name };
+    generateBootOrders(vm) {
+      const disks = vm.spec.template.spec.domain.devices.disks || [];
+      const interfaces = vm.spec.template.spec.domain.devices.interfaces || [];
+
+      const taken = [
+        ...disks,
+        ...interfaces
+      ].map(o => o.bootOrder ?? 0);
+
+      const ret = [...taken];
+
+      let bootOrder = 1;
+
+      for (let i = 0; i < taken.length; i++) {
+        if (!taken[i]) {
+          while (taken.includes(bootOrder)) {
+            bootOrder++;
+          }
+          ret[i] = bootOrder;
+          bootOrder++;
+        }
+      }
+
+      return {
+        disks:      ret.slice(0, disks.length),
+        interfaces: ret.slice(disks.length),
+      };
+    },
+
+    assignBootOrder(elem, bootOrder) {
+      const devices = (elem.type === BOOT_ORDER_TYPE.DISK ? this.diskRows : this.networkRows);
+
+      for (let i = 0; i < devices?.length; i++) {
+        if (devices[i].name === elem.name) {
+          this.$set(devices[i], 'bootOrder', bootOrder);
+          break;
+        }
+      }
+    },
+
+    updateBootOrders(elem) {
+      const existsElem = this.bootOrders.find(({ bootOrder }) => bootOrder === elem.neu);
+
+      this.assignBootOrder(elem, elem.neu);
+
+      if (existsElem) {
+        this.assignBootOrder(existsElem, elem.bootOrder);
+      }
+
+      this.$set(this, 'diskRows', this.diskRows.sort((a, b) => a.bootOrder - b.bootOrder));
+      this.$set(this, 'networkRows', this.networkRows.sort((a, b) => a.bootOrder - b.bootOrder));
+    },
+
+    parseDisk(R) {
+      const out = {
+        name:      R.name,
+        bootOrder: R.bootOrder
+      };
 
       if (R.type === HARD_DISK) {
         out.disk = { bus: R.bus };
       } else if (R.type === CD_ROM) {
         out.cdrom = { bus: R.bus };
       }
-
-      out.bootOrder = index + 1;
 
       return out;
     },
@@ -947,7 +1022,7 @@ export default {
       return arr.map( id => this.getSSHValue(id)).filter( O => O !== undefined);
     },
 
-    parseInterface(R, index) {
+    parseInterface(R) {
       const _interface = {};
       const type = R.type;
 
@@ -960,7 +1035,7 @@ export default {
       _interface.model = R.model;
       _interface.name = R.name;
 
-      _interface.bootOrder = index + 1;
+      _interface.bootOrder = R.bootOrder;
 
       return _interface;
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Fixes https://github.com/harvester/harvester/issues/3325
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### TODO

- check errors in case of removing tabs -> possible infinite lopp

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->


- VM Network tab -> bootOrder field

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- VM Volumes tab -> bootOrder field

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Edit VM, Networks

![image](https://github.com/harvester/dashboard/assets/26394656/06b0b30c-0bf2-4447-a373-495f27e3f8a3)

VM tooltip

![image](https://github.com/harvester/dashboard/assets/26394656/86e347b8-1bcb-4af4-b023-820bebc0da46)


YAML

![image](https://github.com/harvester/dashboard/assets/26394656/f0d5657e-a01f-40c6-a574-15296c4eb737)

