### PR TITLE
Fix volume status Not-Ready

### DIFF
--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -232,7 +232,7 @@ export default class HciPv extends HarvesterResource {
     let ready = true;
     const longhornVolume = this.longhornVolume || {};
 
-    const scheduledCondition = (longhornVolume?.status?.conditions || []).find(c => c.type === 'scheduled') || {};
+    const scheduledCondition = (longhornVolume?.status?.conditions || []).find(c => c.type === 'Scheduled') || {};
 
     if ((longhornVolume?.spec?.nodeID === '' && longhornVolume?.status?.state !== 'detached') ||
           (longhornVolume?.status?.state === 'detached' && scheduledCondition.status !== 'True') ||

--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -232,7 +232,7 @@ export default class HciPv extends HarvesterResource {
     let ready = true;
     const longhornVolume = this.longhornVolume || {};
 
-    const scheduledCondition = (longhornVolume?.status?.conditions || []).find(c => c.type === 'Scheduled') || {};
+    const scheduledCondition = (longhornVolume?.status?.conditions || []).find(c => c.type === 'Scheduled' || c.type === 'scheduled') || {};
 
     if ((longhornVolume?.spec?.nodeID === '' && longhornVolume?.status?.state !== 'detached') ||
           (longhornVolume?.status?.state === 'detached' && scheduledCondition.status !== 'True') ||


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Fix Harvester issue of volume status not-ready.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Fixes #
<!-- Define findings related to the feature or bug issue. -->

https://github.com/harvester/harvester/issues/5020

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->