### PR TITLE
Handle `nvidia-toolkit-driver` addon spec

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.addon/nvidia-driver-toolkit.vue
+++ b/pkg/harvester/edit/harvesterhci.io.addon/nvidia-driver-toolkit.vue
@@ -1,16 +1,25 @@
 <script>
+import merge from 'lodash/merge';
+import jsyaml from 'js-yaml';
+import { clone } from '@shell/utils/object';
 import Tabbed from '@shell/components/Tabbed';
 import Tab from '@shell/components/Tabbed/Tab';
 import { RadioGroup } from '@components/Form/Radio';
+import { LabeledInput } from '@components/Form/LabeledInput';
+import { Banner } from '@components/Banner';
 
 import CreateEditView from '@shell/mixins/create-edit-view';
+
+const DEFAULT_VALUE = {};
 
 export default {
   name:       'EditAddonNvidiaDriverToolkit',
   components: {
+    Banner,
+    LabeledInput,
+    RadioGroup,
     Tabbed,
     Tab,
-    RadioGroup,
   },
 
   mixins: [CreateEditView],
@@ -26,26 +35,115 @@ export default {
       required: true
     },
   },
+
+  data() {
+    return {
+      initSpec:          clone(this.value.spec),
+      valuesContentJson: this.parseValuesContent()
+    };
+  },
+
+  watch: {
+    valuesContentJson: {
+      handler(neu) {
+        this.update(neu);
+      },
+      deep: true,
+    }
+  },
+
+  computed: {
+    parsingSpecError() {
+      return this.valuesContentJson && (this.valuesContentJson.image === undefined || this.valuesContentJson.driverLocation === undefined);
+    }
+  },
+
+  methods: {
+    parseValuesContent() {
+      try {
+        return merge({}, DEFAULT_VALUE, jsyaml.load(this.value.spec.valuesContent));
+      } catch (err) {
+        this.$store.dispatch('growl/fromError', {
+          title: this.$store.getters['i18n/t']('generic.notification.title.error'),
+          err:   err.data || err,
+        }, { root: true });
+
+        return DEFAULT_VALUE;
+      }
+    },
+
+    toggleEnable(v) {
+      this.resetSpec();
+      this.value.spec.enabled = v;
+    },
+
+    resetSpec() {
+      this.value.spec = clone(this.initSpec);
+
+      this.valuesContentJson = this.parseValuesContent();
+    },
+
+    update(values) {
+      this.value.spec.valuesContent = jsyaml.dump(values);
+    }
+  }
 };
 </script>
 
 <template>
-  <Tabbed :side-tabs="true">
-    <Tab
-      name="basic"
-      :label="t('harvester.addons.nvidiaDriverToolkit.titles.basic')"
-      :weight="99"
-    >
-      <RadioGroup
-        v-model="value.spec.enabled"
-        class="mb-20"
-        name="model"
-        :mode="mode"
-        :options="[true,false]"
-        :labels="[t('generic.enabled'), t('generic.disabled')]"
-      />
-    </Tab>
-  </Tabbed>
+  <div>
+    <Banner
+      v-if="parsingSpecError"
+      color="error"
+      :label="t('harvester.addons.nvidiaDriverToolkit.parsingSpecError', null, { raw: true })"
+    />
+    <Tabbed v-else :side-tabs="true">
+      <Tab
+        name="basic"
+        :label="t('harvester.addons.nvidiaDriverToolkit.titles.basic')"
+        :weight="1"
+      >
+        <RadioGroup
+          :value="value.spec.enabled"
+          class="mb-20"
+          name="model"
+          :mode="mode"
+          :options="[true,false]"
+          :labels="[t('generic.enabled'), t('generic.disabled')]"
+          @input="toggleEnable"
+        />
+        <div v-if="value.spec.enabled">
+          <div v-if="valuesContentJson.image" class="row mb-15">
+            <div class="col span-6">
+              <LabeledInput
+                v-model="valuesContentJson.image.repository"
+                :mode="mode"
+                :required="true"
+                label-key="harvester.addons.nvidiaDriverToolkit.image.repository"
+              />
+            </div>
+            <div class="col span-6">
+              <LabeledInput
+                v-model="valuesContentJson.image.tag"
+                :mode="mode"
+                :required="true"
+                class="col span-6"
+                label-key="harvester.addons.nvidiaDriverToolkit.image.tag"
+              />
+            </div>
+          </div>
+          <div class="row mb-15">
+            <LabeledInput
+              v-model="valuesContentJson.driverLocation"
+              :mode="mode"
+              :required="true"
+              label-key="harvester.addons.nvidiaDriverToolkit.driver.location"
+            />
+          </div>
+        </div>
+      </Tab>
+    </Tabbed>
+  </div>
 </template>
 
 <style lang="scss" scoped>

--- a/pkg/harvester/edit/harvesterhci.io.addon/nvidia-driver-toolkit.vue
+++ b/pkg/harvester/edit/harvesterhci.io.addon/nvidia-driver-toolkit.vue
@@ -10,7 +10,7 @@ import { Banner } from '@components/Banner';
 
 import CreateEditView from '@shell/mixins/create-edit-view';
 
-const DEFAULT_VALUE = {};
+const DEFAULT_VALUE = { image: { repo: 'rancher/harvester-nvidia-driver-toolkit' } };
 
 export default {
   name:       'EditAddonNvidiaDriverToolkit',
@@ -116,7 +116,7 @@ export default {
           <div v-if="valuesContentJson.image" class="row mb-15">
             <div class="col span-6">
               <LabeledInput
-                v-model="valuesContentJson.image.repository"
+                v-model="valuesContentJson.image.repo"
                 :mode="mode"
                 :required="true"
                 label-key="harvester.addons.nvidiaDriverToolkit.image.repository"

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1129,6 +1129,15 @@ harvester:
     nvidiaDriverToolkit:
       titles:
         basic: Controller
+        image: Image
+        driver: Driver
+      image:
+        tag: Image Tag
+        repository: Image Repository
+      driver:
+        location: Driver Location
+      parsingSpecError:
+        The field 'spec.valuesContent' has invalid format.
 
   loadBalancer:
     label: Load Balancers


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Fixes https://github.com/harvester/harvester/issues/5112
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

it adds fields to specify the nvidia addon settings, when enabling.
Spec fields are hidden when user switch to 'disable' and values are reset.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

`nvidia-driver-toolkit` addon edit / view page

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Edit 

![303446141-5660dd6d-80dc-4c1c-a406-4551b7090ee7](https://github.com/harvester/dashboard/assets/26394656/939cfb57-dfb6-421d-9db5-4f6466157357)

View

![303447413-f1a227a1-adfd-4b49-9f07-4f973e85139b](https://github.com/harvester/dashboard/assets/26394656/a31ef877-c560-4086-82e8-1adf2841b836)



