### PR TITLE
Allow adding `Checksum` when creating a new image from URL

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
@@ -323,7 +323,7 @@ export default {
               v-model="value.spec.url"
               :mode="mode"
               :disabled="isEdit"
-              class="labeled-input--tooltip"
+              class="mb-20 labeled-input--tooltip"
               required
               label-key="harvester.image.url"
               :tooltip="t('harvester.image.urlTip', {}, true)"
@@ -365,6 +365,15 @@ export default {
                 {{ uploadFileName }}
               </div>
             </div>
+
+            <LabeledInput
+              v-if="value.spec.sourceType === 'download'"
+              v-model="value.spec.checksum"
+              :mode="mode"
+              :disabled="isEdit"
+              label-key="harvester.image.checksum"
+              :tooltip="t('harvester.image.checksumTip')"
+            />
           </div>
         </div>
       </Tab>

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -285,6 +285,8 @@ harvester:
     image:
       ruleTip: 'The URL you have entered ends in an extension that we do not support. We only accept image files that end in .img, .iso, .qcow, .qcow2, .raw.'
       ruleFileTip: 'The file you have chosen ends in an extension that we do not support. We only accept image files that end in .img, .iso, .qcow, .qcow2, .raw.'
+    hash:
+      sha512: 'Invalid SHA512 checksum.'
 
   dashboard:
     label: Dashboard
@@ -702,6 +704,8 @@ harvester:
         =1 {1 image is uploading, please do not refresh or close the page.}
         other {{count} images are uploading, please do not refresh or close the page.}
         }
+    checksum: Checksum
+    checksumTip: Validate the image using the SHA512 checksum, if specified.
 
   vmTemplate:
     label: Templates

--- a/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
@@ -264,6 +264,15 @@ export default class HciVmImage extends HarvesterResource {
       out.push(fileRequired);
     }
 
+    if (this.spec?.checksum?.length) {
+      const checksumFormat = {
+        path:       'spec.checksum',
+        validators: ['hashSHA512'],
+      };
+
+      out.push(checksumFormat);
+    }
+
     return [
       {
         nullable:       false,

--- a/pkg/harvester/validators/hash.js
+++ b/pkg/harvester/validators/hash.js
@@ -1,0 +1,7 @@
+export function hashSHA512(value, getters, errors, validatorArgs, displayKey) {
+  if (!/^[a-f0-9]{128}$/i.test(value)) {
+    errors.push(getters['i18n/t']('harvester.validation.hash.sha512'));
+  }
+
+  return errors;
+}

--- a/pkg/harvester/validators/index.js
+++ b/pkg/harvester/validators/index.js
@@ -5,6 +5,7 @@ import { backupTarget, ntpServers } from './setting';
 import { volumeSize } from './volume';
 import { rancherMonitoring, rancherLogging } from './monitoringAndLogging';
 import { ranges } from './network';
+import { hashSHA512 } from './hash';
 
 export default {
   imageUrl,
@@ -18,4 +19,5 @@ export default {
   rancherMonitoring,
   rancherLogging,
   ranges,
+  hashSHA512,
 };


### PR DESCRIPTION
![Peek 2024-02-14 17-36](https://github.com/harvester/dashboard/assets/1897962/beeb0745-eee2-437f-bbe4-803c1064bf18)

![grafik](https://github.com/harvester/dashboard/assets/1897962/f81ed06a-ad2a-431f-b3ca-72b571ef6869)

- Add validator at model level (legacy) because the whole page is not using form field validators.

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Fixes https://github.com/harvester/harvester/issues/5141
