### PR TITLE
Modify the z-index of tooltips

### DIFF
--- a/shell/assets/styles/base/_variables.scss
+++ b/shell/assets/styles/base/_variables.scss
@@ -31,10 +31,10 @@ $z-indexes: (
   modalOverlay: 20,
   modalContent: 21,
 
-  tooltip: 30,
+  dropdownOverlay: 30,
+  dropdownContent: 31,
 
-  dropdownOverlay: 40,
-  dropdownContent: 41,
+  tooltip: 40,
 
   loadingOverlay: 50,
   loadingContent: 51

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -881,9 +881,6 @@ export default {
     width: 280px;
     display: inline-block;
 
-    $glass-z-index: 2;
-    $dropdown-z-index: 1000;
-
     .ns-glass {
       height: 100vh;
       left: 0;
@@ -891,7 +888,7 @@ export default {
       position: absolute;
       top: 0;
       width: 100vw;
-      z-index: $glass-z-index;
+      z-index: z-index('overContent');
     }
 
     .ns-controls {
@@ -943,7 +940,7 @@ export default {
       margin-top: -1px;
       padding-bottom: 10px;
       position: relative;
-      z-index: $dropdown-z-index;
+      z-index: z-index('dropdownOverlay');
 
       .ns-options {
         max-height: 50vh;
@@ -1055,7 +1052,7 @@ export default {
       height: 40px;
       padding: 0 10px;
       position: relative;
-      z-index: $dropdown-z-index;
+      z-index: z-index('dropdownOverlay');
 
       &.ns-open {
         border-bottom-left-radius: 0;


### PR DESCRIPTION
![grafik](https://github.com/harvester/dashboard/assets/1897962/a470b113-72b0-4a58-95b6-2ec2993d61b9)

... to prevent showing up the `NamespaceFilter` component above `VPopover` (which internally applies the `tooltip` class).

Tooltips should always show up above anything else in general (except the `Loading` component). This follows the common practice and e.g. the Bootstrap z-index specs (https://getbootstrap.com/docs/5.2/layout/z-index/) as a reference.

### Summary

Fixes https://github.com/harvester/harvester/issues/5155
