### PR TITLE
Hide progress bars for VM Backup Created before v1.3

### DIFF
--- a/pkg/harvester/formatters/HarvesterBackupProgressBar.vue
+++ b/pkg/harvester/formatters/HarvesterBackupProgressBar.vue
@@ -14,10 +14,10 @@ export default {
 
   computed: {
     isEmpty() {
-      return this.value !== undefined && Object.keys(this.value).length === 0;
+      return this.value?.percentage === undefined;
     },
     status() {
-      switch (this.value.percentage) {
+      switch (this.value?.percentage) {
       case 0:
         return 'starting';
       case 100:
@@ -47,7 +47,7 @@ export default {
     },
 
     tooltip() {
-      if (!this.value.details.volumes?.length) {
+      if (!this.value?.details?.volumes?.length) {
         return null;
       }
       const title = this.t(`harvester.${ this.value.type }.progress.details`);

--- a/pkg/harvester/list/harvesterhci.io.virtualmachinebackup.vue
+++ b/pkg/harvester/list/harvesterhci.io.virtualmachinebackup.vue
@@ -90,7 +90,7 @@ export default {
 
   computed: {
     headers() {
-      return [
+      const cols = [
         STATE,
         NAME,
         NAMESPACE,
@@ -115,16 +115,26 @@ export default {
           align:     'left',
           formatter: 'Checked',
         },
-        {
+      ];
+
+      if (this.hasBackupProgresses) {
+        cols.push({
           name:      'backupProgress',
           labelKey:  'tableHeaders.progress',
           value:     'backupProgress',
           align:     'left',
           formatter: 'HarvesterBackupProgressBar',
           width:     200,
-        },
-        AGE
-      ];
+        });
+      }
+
+      cols.push(AGE);
+
+      return cols;
+    },
+
+    hasBackupProgresses() {
+      return !!this.rows.find(R => R.status?.progress !== undefined);
     },
 
     filteredRows() {

--- a/pkg/harvester/models/harvesterhci.io.virtualmachinebackup.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachinebackup.js
@@ -136,8 +136,8 @@ export default class HciVmBackup extends HarvesterResource {
   get backupProgress() {
     return {
       type:       BACKUP_TYPE.BACKUP,
-      percentage: this.status?.progress || 0,
-      details:    { volumes: this.status?.volumeBackups || [] }
+      percentage: this.status?.progress === undefined && !this.status?.readyToUse ? 0 : this.status?.progress,
+      details:    { volumes: this.status?.volumeBackups }
     };
   }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Harvester should show progress info only for backups containing those info, (created in >= `v1.3.0`).

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Resolves https://github.com/harvester/harvester/issues/5068/
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Relevant change:

```
 percentage: this.status?.progress === undefined && !this.status?.readyToUse ? 0 : this.status?.progress,
```

Cases:

- `status.progress` is undefined and `status?.readyToUse` is false: It means that new backup has not received the progress info yet but it will do; the progress bar should show `0`
- `status.progress` is undefined and `status?.readyToUse` is true: It is a backup created in v1.2.x; It should show dash character (`isEmpty` in `HarvesterBackupProgressBar.vue`)
- `status.progress` is between 0 and 100: It is a new backup; It should show the percentage while creating and then 'completed' label once finished.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Backups page

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Remove progress bar info for backups created in v1.2.x

![image](https://github.com/harvester/dashboard/assets/26394656/37c4e231-2bb4-4d44-ac7e-f7b2fd95d453)


'Progress' column removed if all backups created in v1.2.x

![image](https://github.com/harvester/dashboard/assets/26394656/e1886e53-3a09-4925-933c-e766a35a3ffb)


