### PR TITLE
Add getters argument to `updateNamespaces` store function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In this mode, you need to have Rancher and import Harvester, more detail in [Har
 yarn build-pkg harvester && yarn serve-pkgs
 
 # Open another terminal
-HARVESTER_PKG_URL=http://127.0.0.1:4500/harvester-${version}/harvester-${version}.umd.min.js API=https://your-rancher-ip yarn mem-dev
+HARVESTER_PKG_URL=http://127.0.0.1:4500/harvester-${version}/harvester-${version}.umd.min.js API=https://your-rancher-ip RANCHER_ENV=harvester yarn mem-dev
 
 # Example 
 # HARVESTER_PKG_URL=http://127.0.0.1:4500/harvester-1.2.0/harvester-1.2.0.umd.min.js API=https://192.168.1.122 yarn mem-dev

--- a/pkg/harvester/store/harvester-store/actions.ts
+++ b/pkg/harvester/store/harvester-store/actions.ts
@@ -101,6 +101,7 @@ export default {
     commit('updateNamespaces', {
       filters: [],
       all:     getters.filterNamespace(),
+      getters
     }, { root: true });
 
     // Solve compatibility with Rancher v2.6.x, fell remove these codes after not support v2.6.x

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -590,7 +590,7 @@ export const mutations = {
     state.isRancherInHarvester = neu;
   },
 
-  updateNamespaces(state, { filters, all }) {
+  updateNamespaces(state, { filters, all, getters }) {
     state.namespaceFilters = filters.filter(x => !!x);
 
     if ( all ) {
@@ -943,6 +943,7 @@ export const actions = {
     commit('updateNamespaces', {
       filters: filters || [ALL_USER],
       all:     allNamespaces,
+      getters
     });
 
     if (getters['currentCluster'] && getters['currentCluster'].isHarvester) {
@@ -965,7 +966,7 @@ export const actions = {
       }
     });
 
-    commit('updateNamespaces', { filters: ids });
+    commit('updateNamespaces', { filters: ids, getters });
   },
 
   async cleanNamespaces({ getters, dispatch }) {

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -590,7 +590,7 @@ export const mutations = {
     state.isRancherInHarvester = neu;
   },
 
-  updateNamespaces(state, { filters, all, getters }) {
+  updateNamespaces(state, { filters, all, getters: optGetters }) {
     state.namespaceFilters = filters.filter(x => !!x);
 
     if ( all ) {
@@ -598,7 +598,7 @@ export const mutations = {
     }
     // Create map that can be used to efficiently check if a
     // resource should be displayed
-    getActiveNamespaces(state, getters);
+    getActiveNamespaces(state, optGetters || getters);
   },
 
   changeAllNamespaces(state, namespace) {


### PR DESCRIPTION
### TODO

Open the related issue in `harvester` repo.

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This is a porting of `shell` code changes from `rancher/dashboard` code base to preserver the compatibility in embedded mode with Rancher UI `v2.9-head`.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related issue https://github.com/rancher/dashboard/issues/10647
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The `getters` paramter has been added to `updateNamespaces` in the shell package, in Rancher code base.
The `updateNamespaces` function from Rancher store's shell, where `getters` is required, is overlapping the one in Harvester shell when using it in embedded mode.
The `getters` param is always null in Harvester store, since it is not pushing the `getters` param:

```
  commit('updateNamespaces', {
    filters: [],
    all:     getters.filterNamespace(),
    // getters
  }, { root: true });
```
and this is causing the `undefined` error in the Rancher dashboard.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- The shell code change should be compatible with all Rancher Manager supported versions.
- To test Harvester embedded mode, with Rancher v2.9-head, v2.8 and v2.7

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Namespace filter

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->