### PR TITLE
Take image virtual size into account when creating VMs

### DIFF
--- a/pkg/harvester/config/harvester.js
+++ b/pkg/harvester/config/harvester.js
@@ -28,6 +28,7 @@ import {
 
 import {
   IMAGE_DOWNLOAD_SIZE,
+  IMAGE_VIRTUAL_SIZE,
   FINGERPRINT,
   IMAGE_PROGRESS,
   SNAPSHOT_TARGET_VOLUME,
@@ -220,6 +221,7 @@ export function init($plugin, store) {
     NAMESPACE_COL,
     IMAGE_PROGRESS,
     IMAGE_DOWNLOAD_SIZE,
+    IMAGE_VIRTUAL_SIZE,
     AGE
   ]);
   virtualType({

--- a/pkg/harvester/config/table-headers.js
+++ b/pkg/harvester/config/table-headers.js
@@ -11,6 +11,14 @@ export const IMAGE_DOWNLOAD_SIZE = {
   width:    120
 };
 
+export const IMAGE_VIRTUAL_SIZE = {
+  name:     'virtualSize',
+  labelKey: 'harvester.tableHeaders.virtualSize',
+  value:    'virtualSize',
+  sort:     'status.virtualSize',
+  width:    120
+};
+
 export const IMAGE_PROGRESS = {
   name:      'Uploaded',
   labelKey:  'tableHeaders.progress',

--- a/pkg/harvester/detail/harvesterhci.io.virtualmachineimage/index.vue
+++ b/pkg/harvester/detail/harvesterhci.io.virtualmachineimage/index.vue
@@ -35,6 +35,10 @@ export default {
       return this.value?.downSize;
     },
 
+    virtualSize() {
+      return this.value?.virtualSize;
+    },
+
     url() {
       return this.value?.spec?.url || '-';
     },
@@ -97,6 +101,12 @@ export default {
       <div class="row">
         <div class="col span-12">
           <LabelValue :name="t('harvester.image.size')" :value="formattedValue" class="mb-20" />
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col span-12">
+          <LabelValue :name="t('harvester.image.virtualSize')" :value="virtualSize" class="mb-20" />
         </div>
       </div>
 

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -140,13 +140,24 @@ export default {
 
     onImageChange() {
       const imageResource = this.$store.getters['harvester/all'](HCI.IMAGE)?.find( I => this.value.image === I.id);
+      const isIsoImage = /iso$/i.test(imageResource?.imageSuffix);
+      const imageSize = Math.max(imageResource?.status?.size, imageResource?.status?.virtualSize);
 
-      if (/iso$/i.test(imageResource?.imageSuffix)) {
+      if (isIsoImage) {
         this.$set(this.value, 'type', 'cd-rom');
         this.$set(this.value, 'bus', 'sata');
       } else {
         this.$set(this.value, 'type', 'disk');
         this.$set(this.value, 'bus', 'virtio');
+      }
+
+      if (imageSize) {
+        let imageSizeGiB = Math.ceil(imageSize / 1024 / 1024 / 1024);
+
+        if (!isIsoImage) {
+          imageSizeGiB = Math.max(imageSizeGiB, 10);
+        }
+        this.$set(this.value, 'size', `${ imageSizeGiB }Gi`);
       }
 
       this.update();

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -141,14 +141,12 @@ export default {
     onImageChange() {
       const imageResource = this.$store.getters['harvester/all'](HCI.IMAGE)?.find( I => this.value.image === I.id);
 
-      if (this.idx === 0) {
-        if (/iso$/i.test(imageResource?.imageSuffix)) {
-          this.$set(this.value, 'type', 'cd-rom');
-          this.$set(this.value, 'bus', 'sata');
-        } else {
-          this.$set(this.value, 'type', 'disk');
-          this.$set(this.value, 'bus', 'virtio');
-        }
+      if (/iso$/i.test(imageResource?.imageSuffix)) {
+        this.$set(this.value, 'type', 'cd-rom');
+        this.$set(this.value, 'bus', 'sata');
+      } else {
+        this.$set(this.value, 'type', 'disk');
+        this.$set(this.value, 'bus', 'virtio');
       }
 
       this.update();

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -159,6 +159,7 @@ harvester:
     forceStop: Force Stop
   tableHeaders:
     size: Size
+    virtualSize: Virtual Size
     progress: Progress
     message: Message
     phase: Phase
@@ -696,6 +697,7 @@ harvester:
       basics: Basics
     url: URL
     size: Size
+    virtualSize: Virtual Size
     urlTip: 'supports the <code>raw</code> and <code>qcow2</code> image formats which are supported by <a href="https://www.qemu.org/docs/master/system/images.html#disk-image-file-formats" target="_blank">qemu</a>. Bootable ISO images can also be used and are treated like <code>raw</code> images.'
     fileName: File Name
     uploadFile: Upload File

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -414,12 +414,24 @@ export default {
       if (_disks.length === 0) {
         let bus = 'virtio';
         let type = HARD_DISK;
+        let size = '10Gi';
 
         const imageResource = this.images.find( I => this.imageId === I.id);
+        const isIsoImage = /iso$/i.test(imageResource?.imageSuffix);
+        const imageSize = Math.max(imageResource?.status?.size, imageResource?.status?.virtualSize);
 
-        if (/iso$/i.test(imageResource?.imageSuffix)) {
+        if (isIsoImage) {
           bus = 'sata';
           type = CD_ROM;
+        }
+
+        if (imageSize) {
+          let imageSizeGiB = Math.ceil(imageSize / 1024 / 1024 / 1024);
+
+          if (!isIsoImage) {
+            imageSizeGiB = Math.max(imageSizeGiB, 10);
+          }
+          size = `${ imageSizeGiB }Gi`;
         }
 
         out.push({
@@ -429,7 +441,7 @@ export default {
           accessMode:       'ReadWriteMany',
           bus,
           volumeName:       '',
-          size:             '10Gi',
+          size,
           type,
           storageClassName: '',
           image:            this.imageId,

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -412,15 +412,25 @@ export default {
       let out = [];
 
       if (_disks.length === 0) {
+        let bus = 'virtio';
+        let type = HARD_DISK;
+
+        const imageResource = this.images.find( I => this.imageId === I.id);
+
+        if (/iso$/i.test(imageResource?.imageSuffix)) {
+          bus = 'sata';
+          type = CD_ROM;
+        }
+
         out.push({
           id:               randomStr(5),
           source:           SOURCE_TYPE.IMAGE,
           name:             'disk-0',
           accessMode:       'ReadWriteMany',
-          bus:              'virtio',
+          bus,
           volumeName:       '',
           size:             '10Gi',
-          type:             HARD_DISK,
+          type,
           storageClassName: '',
           image:            this.imageId,
           volumeMode:       'Block',

--- a/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
@@ -168,6 +168,21 @@ export default class HciVmImage extends HarvesterResource {
     });
   }
 
+  get virtualSize() {
+    const virtualSize = this.status?.virtualSize;
+
+    if (!virtualSize) {
+      return '-';
+    }
+
+    return formatSi(virtualSize, {
+      increment:    1024,
+      maxPrecision: 2,
+      suffix:       'B',
+      firstSuffix:  'B',
+    });
+  }
+
   getStatusConditionOfType(type, defaultValue = []) {
     const conditions = Array.isArray(get(this, 'status.conditions')) ? this.status.conditions : defaultValue;
 


### PR DESCRIPTION
Prior to this, the default size for volumes attached to VMs was 10GiB, regardless of the size of the underlying image.  This is fine if the image is smaller, but if the image is either physically larger (as in the case of a >10GiB ISO), or has a larger virtual size (as can be true with qcow2 images), the result is a corrupt volume.
    
This PR fixes the problem by checking both the physical size and virtual size of the image, and using whichever is greater as the default size of the volume.  Virtual size should always be >= physical size, but it is still theoretically possible for either value to be zero in case of error, so taking the greater of the two is the safest approach.
    
There are two exceptions to the above rule:
    
1) For non-ISO images, if the image is < 10GiB, we still default to a size of 10GiB for consistency with the behaviour of earlier Harvester releases.  The user can always lower this if they want/need to.
2) ISO images smaller than 1GiB will be given a size of 1GiB, simply because the size control in the UI is set to work in GiB units.  It is actually possible to get a value of 0.2 GiB in there for a 200MiB ISO, but doing that is pretty ugly IMO, and there's no real harm in having the volume that backs a CD-ROM image be a bit larger than the source in this case.

This PR also adds Virtual Size as an additional column when listing images. I don't know whether or not this is the best way to present this information. Another alternative could be to make the existing Size column simply report the greater of Size and Virtual Size, on the assumption that what you really care about is the size that a volume needs to be when based on that image.

I've included a couple other small tweaks as well relating to automatically setting disk type and bus for ISO images (see the commit messages for details).

Note that this PR depends on https://github.com/harvester/harvester/pull/5387 which in turn depends on changes in Longhorn.

Related issue: https://github.com/harvester/harvester/issues/5142
Related issue: https://github.com/harvester/harvester/issues/4905
Related issue: https://github.com/harvester/harvester/issues/2189