### PR TITLE
[release-v1.2] Remove orgId param in grafana link

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.addon/rancher-monitoring.vue
+++ b/pkg/harvester/edit/harvesterhci.io.addon/rancher-monitoring.vue
@@ -168,7 +168,7 @@ export default {
           iconSrc:     grafanaSrc,
           label:       'monitoring.overview.linkedList.grafana.label',
           description: 'monitoring.overview.linkedList.grafana.description',
-          link:        `/k8s/clusters/${ currentCluster.id }/api/v1/namespaces/${ CATTLE_MONITORING_NAMESPACE }/services/http:rancher-monitoring-grafana:80/proxy/?orgId=1`,
+          link:        `/k8s/clusters/${ currentCluster.id }/api/v1/namespaces/${ CATTLE_MONITORING_NAMESPACE }/services/http:rancher-monitoring-grafana:80/proxy`,
         },
         prometheus: {
           enabled:     false,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Fixes #
<!-- Define findings related to the feature or bug issue. -->

With the new PR https://github.com/harvester/harvester-installer/pull/681 to bump `rancher-monitoring` in Harvester v1.2.2, the embedded Rancher was also bumped to v2.8.2.

The current UI will have such error:
![image](https://github.com/harvester/dashboard/assets/31133476/5e15f43c-eb50-40be-ae9b-1b514a361d2e)

![image](https://github.com/harvester/dashboard/assets/31133476/9d7bac01-6069-4ac2-9f52-e95803e2d4ff)

After remove `/?orgId=1` from the link, it works.

```
 <a data-v-778364ee="" data-v-590b7fec="" href="/k8s/clusters/local/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/?orgId=1" target="_blank" rel="noopener nofollow"> ...
```


### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->