### PR TITLE
feat: reconnect after disconnecting

### DIFF
--- a/pkg/harvester/components/novnc/NovncConsole.vue
+++ b/pkg/harvester/components/novnc/NovncConsole.vue
@@ -13,6 +13,15 @@
         </div>
       </main>
     </div>
+    <div v-if="reconnecting">
+      <main class="main-layout">
+        <div class="text-center">
+          <h2 class="text-secondary mt-20">
+            {{ t('vncConsole.reconnecting.message') }}：{{ retryTimes }} of {{ maximumRetryTimes }}
+          </h2>
+        </div>
+      </main>
+    </div>
     <div
       ref="view"
     />
@@ -35,28 +44,71 @@ export default {
 
   data() {
     return {
-      rfb:          null,
-      connected:    false,
-      disconnected: false,
+      rfb:               null,
+      connected:         false,
+      disconnected:      false,
+      reconnectDelay:    3000,
+      reconnecting:      false,
+      maximumRetryTimes: 10,
+      retryTimes:        0,
+      setTimeout:        null,
     };
   },
 
   mounted() {
     this.$nextTick(() => {
-      const rfb = new RFB(this.$refs.view, this.url);
-
-      rfb.addEventListener('connect', () => {
-        this.connected = true;
-      });
-      rfb.addEventListener('disconnect', (e) => {
-        this.disconnected = true;
-      });
-
-      this.rfb = rfb;
+      this.connect();
     });
   },
 
   methods: {
+    connect() {
+      const rfb = new RFB(this.$refs.view, this.url);
+
+      rfb.addEventListener('connect', () => {
+        this.clearTimeout();
+
+        this.connected = true;
+        this.retryTimes = 0;
+        this.reconnecting = false;
+      });
+
+      rfb.addEventListener('disconnect', (e) => {
+        this.clearTimeout();
+
+        this.disconnected = true;
+        this.rfb = null;
+        this.reconnect();
+      });
+
+      this.rfb = rfb;
+    },
+
+    reconnect() {
+      if (this.retryTimes >= this.maximumRetryTimes) {
+        this.reconnecting = false;
+        this.connected = true;
+        this.disconnected = true;
+
+        return;
+      }
+
+      this.retryTimes += 1;
+      this.reconnecting = true;
+      this.connected = false;
+      this.disconnected = false;
+
+      this.setTimeout = setTimeout(() => {
+        this.connect();
+      }, this.reconnectDelay);
+    },
+
+    clearTimeout() {
+      if (this.setTimeout) {
+        clearTimeout(this.setTimeout);
+      }
+    },
+
     disconnect() {
       this.rfb.disconnect();
     },

--- a/pkg/harvester/components/novnc/NovncConsole.vue
+++ b/pkg/harvester/components/novnc/NovncConsole.vue
@@ -61,6 +61,10 @@ export default {
     });
   },
 
+  beforeDestroy() {
+    this.clearTimeout();
+  },
+
   methods: {
     connect() {
       const rfb = new RFB(this.$refs.view, this.url);

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7332,7 +7332,9 @@ auth:
     label: Auth Provider
 vncConsole:
   error:
-    message: Web VNC console connection is disconnected
+    message: Web VNC console is disconnected
+  reconnecting:
+    message: Web VNC console reconnection attempt
 
 networkAttachmentDefinition:
   tabs:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue: https://github.com/harvester/harvester/issues/2242
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Currently, after disconnecting, our vnc doesn't automatically connect. Users need to refresh page to connect it again.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
I checked the [official demo of noVNC](https://novnc.com/noVNC/vnc.html) about how to reconnect , you could check [source code](https://novnc.com/noVNC/app/ui.js). It reconnects the vnc after disconnecting event happens. So I use similar way to do reconnecting.

${\color{red}\text{I just added a very simple sentence to tell users VNC is reconnecting, please let me know if there is a better prompt}}$

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

About how to reproduce disconnecting, just shutdown the develop server and start it again.

https://github.com/harvester/dashboard/assets/6960289/bc7b403d-1f2e-49d1-8f23-b99c211b86a7


New Demo for reconnecting exceeds 10 times.

https://github.com/harvester/dashboard/assets/6960289/cc50bead-dcc3-40a5-ba00-c62386b63e4f


