### PR TITLE
Using vmimage.status.storageClassName to fill volumeClaimTemplates

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.volume.vue
+++ b/pkg/harvester/edit/harvesterhci.io.volume.vue
@@ -228,11 +228,13 @@ export default {
       let storageClassName = this.value.spec.storageClassName;
 
       if (this.isVMImage && this.imageId) {
+        const images = this.$store.getters['harvester/all'](HCI.IMAGE);
+
         imageAnnotations = {
           ...this.value.metadata.annotations,
           [HCI_ANNOTATIONS.IMAGE_ID]: this.imageId
         };
-        storageClassName = `longhorn-${ this.imageId.split('/')[1] }`;
+        storageClassName = images?.find(image => this.imageId === image.id)?.storageClassName;
       } else {
         imageAnnotations = { ...this.value.metadata.annotations };
       }

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -928,7 +928,7 @@ export default {
         const image = this.images.find( I => R.image === I.id);
 
         if (image) {
-          out.spec.storageClassName = `longhorn-${ image.metadata.name }`;
+          out.spec.storageClassName = image.storageClassName;
           out.metadata.annotations = { [HCI_ANNOTATIONS.IMAGE_ID]: image.id };
         } else {
           out.metadata.annotations = { [HCI_ANNOTATIONS.IMAGE_ID]: '' };

--- a/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
@@ -194,6 +194,10 @@ export default class HciVmImage extends HarvesterResource {
     return this.spec?.displayName;
   }
 
+  get storageClassName() {
+    return this.status?.storageClassName || '';
+  }
+
   get uploadImage() {
     return async(file) => {
       const formData = new FormData();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related issue https://github.com/harvester/harvester/issues/5551
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Populating volumeClaimTemplates with vmimage.status.storageClassName intead of `"longhorn-${imageId}"`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->