### PR TITLE
Get `backendPort` as options in Health Check in Load Balance

### DIFF
--- a/pkg/harvester/edit/loadbalancer.harvesterhci.io.loadbalancer/HealthCheck.vue
+++ b/pkg/harvester/edit/loadbalancer.harvesterhci.io.loadbalancer/HealthCheck.vue
@@ -43,6 +43,12 @@ export default {
       return ports.filter(p => p.port && p.protocol === 'TCP').map(p => p.backendPort) || [];
     },
   },
+
+  methods: {
+    onToggle(value) {
+      this.$emit('enabled', value);
+    }
+  }
 };
 </script>
 
@@ -57,6 +63,7 @@ export default {
           :labels="[t('generic.disabled'),t('generic.enabled')]"
           :options="[false, true]"
           :disabled="disabled"
+          @input="onToggle"
         />
       </div>
     </div>

--- a/pkg/harvester/edit/loadbalancer.harvesterhci.io.loadbalancer/HealthCheck.vue
+++ b/pkg/harvester/edit/loadbalancer.harvesterhci.io.loadbalancer/HealthCheck.vue
@@ -40,7 +40,7 @@ export default {
     portOptions() {
       const ports = this.model?.spec?.listeners || [];
 
-      return ports.filter(p => p.port && p.protocol === 'TCP').map(p => p.port) || [];
+      return ports.filter(p => p.port && p.protocol === 'TCP').map(p => p.backendPort) || [];
     },
   },
 };

--- a/pkg/harvester/edit/loadbalancer.harvesterhci.io.loadbalancer/Listeners.vue
+++ b/pkg/harvester/edit/loadbalancer.harvesterhci.io.loadbalancer/Listeners.vue
@@ -175,6 +175,9 @@ export default {
           <input
             v-else
             v-model.number="row.backendPort"
+            type="number"
+            min="1"
+            max="65535"
             :placeholder="t('harvester.loadBalancer.listeners.backendPort.placeholder')"
             @input="queueUpdate"
           />

--- a/pkg/harvester/edit/loadbalancer.harvesterhci.io.loadbalancer/index.vue
+++ b/pkg/harvester/edit/loadbalancer.harvesterhci.io.loadbalancer/index.vue
@@ -159,6 +159,17 @@ export default {
 
       return { activelyRemove };
     },
+
+    healthCheckPortInUseWarning() {
+      const healthCheckPort = this.value?.spec?.healthCheck?.port;
+      const portInUse = this.value?.spec?.listeners?.find(l => l.backendPort === healthCheckPort);
+
+      if (healthCheckPort && portInUse) {
+        return this.t('harvester.loadBalancer.healthCheck.warning.portInUse', { port: portInUse.backendPort }, true);
+      }
+
+      return '';
+    }
   },
 
   methods: {
@@ -270,6 +281,12 @@ export default {
         :weight="98"
         class="bordered-table"
       >
+        <Banner
+          v-if="healthCheckPortInUseWarning"
+          color="warning"
+        >
+          <span v-clean-html="healthCheckPortInUseWarning" />
+        </Banner>
         <Listeners
           v-model="value.spec.listeners"
           class="col span-12"

--- a/pkg/harvester/edit/loadbalancer.harvesterhci.io.loadbalancer/index.vue
+++ b/pkg/harvester/edit/loadbalancer.harvesterhci.io.loadbalancer/index.vue
@@ -196,6 +196,12 @@ export default {
         };
       }
     }, 250, { leading: true }),
+
+    healthCheckEnabled(v) {
+      if (!v) {
+        this.value.spec.healthCheck = {};
+      }
+    }
   },
 
   watch: {
@@ -302,6 +308,7 @@ export default {
           v-model="value.spec.healthCheck"
           :mode="mode"
           :model="value"
+          @enabled="healthCheckEnabled"
         />
       </Tab>
     </ResourceTabs>

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1186,6 +1186,9 @@ harvester:
           }
     backendServers:
       label: Backend Servers
+    healthCheck:
+      warning:
+        portInUse: Warning, Backend Port {port} is in use in Health Check settings; in case of updating the port, update the Health Check settings accordingly.
 
   ipPool:
     label: IP Pools


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related issue https://github.com/harvester/harvester/issues/5444
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

The `listeners.backendPort` is used instead of `listeners.port`, when selecting the port in Health Check tab.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Changing the port data source
- Fixing an issue in Health Check tab: when disabling the Health Box, old fields remain filled in the Load Balancer object (and YAML).
- Adding a warning message to notice the users when a backend port in Listeners tab is used in Heath Check.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Backend port 5000

![image](https://github.com/harvester/dashboard/assets/26394656/19b98717-7910-4e68-8057-51799dde1d54)

Port options in Health Check tab

![image](https://github.com/harvester/dashboard/assets/26394656/7a9f8a56-41df-45e9-997b-ef3628f45792)

Warning message in Listeners when port 5000 is select in Health Box

![image](https://github.com/harvester/dashboard/assets/26394656/45997ecf-cf18-4885-8eee-649c92d1e51a)

