### PR TITLE
Avoid yarn dev warning caused by nonvnc console custom key action style

### DIFF
--- a/pkg/harvester/components/novnc/NovncConsoleCustomKeys.vue
+++ b/pkg/harvester/components/novnc/NovncConsoleCustomKeys.vue
@@ -240,6 +240,6 @@ export default {
   .actions {
     width: 100%;
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
   }
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Occurred changes and/or fixed issues
The div.action justify-context should use `flex-end` to suppress below warning

**Before**
<img width="1079" alt="Screenshot 2024-04-23 at 12 08 01 PM" src="https://github.com/harvester/dashboard/assets/5744158/592e9a49-5ebf-4462-858d-2eb4d2d9f6a7">

**After**
<img width="1441" alt="Screenshot 2024-04-23 at 12 36 22 PM" src="https://github.com/harvester/dashboard/assets/5744158/c634e3f3-946a-4ecd-9ac7-17795a9793a9">


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
Checked on latest version of 
- Chrome  ✅ 
- Edge ✅ 
- Firefox ✅ 
<img width="1401" alt="Screenshot 2024-04-23 at 12 16 29 PM" src="https://github.com/harvester/dashboard/assets/5744158/39fa02b8-3919-4571-b70b-8aa279a9a5c9">

