### PR TITLE
Change the vGPU model to show backend errors properly

### DIFF
--- a/pkg/harvester/models/devices.harvesterhci.io.vgpudevice.js
+++ b/pkg/harvester/models/devices.harvesterhci.io.vgpudevice.js
@@ -100,12 +100,17 @@ export default class VGpuDevice extends SteveModel {
   }
 
   async disableVGpu() {
+    const { vGPUTypeName, enabled } = this.spec;
+
     try {
       this.spec.vGPUTypeName = undefined;
       this.spec.enabled = false;
       await this.save();
     } catch (err) {
-      this.$store.dispatch('growl/fromError', {
+      this.spec.vGPUTypeName = vGPUTypeName;
+      this.spec.enabled = enabled;
+
+      this.$dispatch('growl/fromError', {
         title: this.t('generic.notification.title.error', { name: escapeHtml(this.metadata.name) }),
         err,
       }, { root: true });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related issue https://github.com/harvester/harvester/issues/5293
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`this.$store.dispatch('growl/fromError'...`  is wrong, it should be just `this.$dispatch(...`, so it wasn't display the API errors; It will also need to restore the `spec` values in case of errors.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- vGPU Devices page

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/harvester/dashboard/assets/26394656/ca33a181-4cbe-4fa3-903d-ed6eb800463c)

