### PR TITLE
vm-import-controller Change StorageClassName to StorageClass

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.addon/vm-import-controller.vue
+++ b/pkg/harvester/edit/harvesterhci.io.addon/vm-import-controller.vue
@@ -18,7 +18,7 @@ const VALUES_YAML_KEYS = [
   'resources.limits.memory',
   'pvcClaim.enabled',
   'pvcClaim.size',
-  'pvcClaim.storageClassName',
+  'pvcClaim.storageClass',
 ];
 
 const DEFAULT_VALUES = {
@@ -28,7 +28,7 @@ const DEFAULT_VALUES = {
   'resources.limits.memory':   '4Gi',
   'pvcClaim.enabled':          false,
   'pvcClaim.size':             '200Gi',
-  'pvcClaim.storageClassName': '',
+  'pvcClaim.storageClass': '',
 };
 
 export default {
@@ -108,7 +108,7 @@ export default {
       const inStore = this.$store.getters['currentProduct'].inStore;
       const defaultStorage = this.$store.getters[`${ inStore }/all`](STORAGE_CLASS).find( s => s.isDefault);
 
-      this.$set(this.valuesContent.pvcClaim, 'storageClassName', this.valuesContent?.pvcClaim?.storageClassName || defaultStorage?.metadata?.name || 'longhorn');
+      this.$set(this.valuesContent.pvcClaim, 'storageClass', this.valuesContent?.pvcClaim?.storageClass || defaultStorage?.metadata?.name || 'longhorn');
 
       this.update();
     },
@@ -208,7 +208,7 @@ export default {
               </div>
               <div class="col span-6">
                 <LabeledSelect
-                  v-model="valuesContent.pvcClaim.storageClassName"
+                  v-model="valuesContent.pvcClaim.storageClass"
                   :options="storageClassOptions"
                   :label="t('harvester.storage.storageClass.label')"
                   :mode="mode"


### PR DESCRIPTION
Change StorageClassName to StorageClass to match the chart

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The UI asks for a StorageClass but we pass a StorageClassName, which has no match. Therefore the chart uses the default StorageClass.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Fixes #
<!-- Define findings related to the feature or bug issue. -->
While creating a custom migration scenario, we observed the preferred StorageClass wasn't in use. After looking into it, Gaurav pointed out the incorrect syntax was used.

### Areas or cases that should be tested
Upgrade from 1.2.1, then edit and Save the AddOn.

### Areas which could experience regressions
This change, when Saved, will create another PVC and delete the old one in the correct StorageClass as orignally defined vs the default SC. It could cause disk utilization issues if the user expected them somewhere else (which was originally wrong)
