### PR TITLE
fix: onPaste separator logic in KeyValue.vue

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
@@ -410,15 +410,6 @@ export default {
           @focusKey="focusKey"
           @input="value.setLabels($event)"
         >
-          <template #key="{ row, keyName, queueUpdate}">
-            <input
-              ref="key"
-              v-model="row[keyName]"
-              :placeholder="t('keyValue.keyPlaceholder')"
-              @input="queueUpdate"
-            />
-          </template>
-
           <template #value="{row, keyName, valueName, queueUpdate}">
             <Select
               v-if="internalAnnotations(row)"

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6916,7 +6916,7 @@ podAffinity:
 keyValue:
   keyPlaceholder: e.g. foo
   valuePlaceholder: e.g. bar
-  protip: 'Paste lines of <em>key=value</em> or <em>key: value</em> into any key field for easy bulk entry'
+  protip: 'Paste lines of <em>key=value</em> or <em>key:value</em> into any key field for easy bulk entry'
 
 registryMirror:
   header: Mirrors

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -237,7 +237,7 @@ export default {
     },
     parserSeparators: {
       type:    Array,
-      default: () => [': ', '='],
+      default: () => [':', '='],
     },
     loading: {
       default: false,
@@ -492,14 +492,14 @@ export default {
       }
       this.$emit('input', out);
     },
-    onPaste(index, event, pastedValue) {
+    onPaste(index, event) {
       const text = event.clipboardData.getData('text/plain');
       const lines = text.split('\n');
       const splits = lines.map((line) => {
-        const splitter = !line.includes(':') || ((line.indexOf('=') < line.indexOf(':')) && line.includes(':')) ? '=' : ':';
+        const splitter = this.parserSeparators.find(sep => line.includes(sep));
 
-        return line.split(splitter);
-      });
+        return splitter ? line.split(splitter) : '';
+      }).filter(split => split && split.length > 0);
 
       if (splits.length === 0 || (splits.length === 1 && splits[0].length < 2)) {
         return;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
In Images -> Create -> Labels, follow the tooltip Paste `lines of key=value` or `key:value` into any key field for easy bulk entry and try to paste key=value lines, but not convert to lables automatically.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Fixes # https://github.com/harvester/harvester/issues/4206

### Technical notes summary
KeyValue.vue natively have **onPaste logic** l to convert multi-lines into key:value map.
But have error logic to support `:` separator.
 

### Screenshot/Video
Check this change also fix
- Virtual Machine -> Create ✅ 
- Network -> Load Balancer -> Create  ✅ 
- Image -> Create ✅
  
e.g. paste in key field
```
user-firstname=Andy Lee 
user-lastname=aaa
user-id:123
```
<img width="1484" alt="Screenshot 2024-05-05 at 10 07 51 PM" src="https://github.com/harvester/dashboard/assets/5744158/b4d3336a-daa1-45db-92fc-29e69ec4afd9">
