### PR TITLE
Remove Select a Template from user data and network template option

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineCloudConfig/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineCloudConfig/index.vue
@@ -11,7 +11,6 @@ import { _VIEW } from '@shell/config/query-params';
 import DataTemplate from './DataTemplate';
 
 const _NEW = '_NEW';
-const _NONE = '_NONE';
 
 export default {
   components: {
@@ -81,19 +80,9 @@ export default {
       value: _NEW,
     });
 
-    optionUser.unshift({
-      label: this.t('harvester.virtualMachine.cloudConfig.cloudInit.placeholder'),
-      value: _NONE,
-    });
-
     optionNetwork.unshift({
       label: this.t('harvester.virtualMachine.cloudConfig.createNew'),
       value: _NEW,
-    });
-
-    optionNetwork.unshift({
-      label: this.t('harvester.virtualMachine.cloudConfig.cloudInit.placeholder'),
-      value: _NONE,
     });
 
     this.optionUser = optionUser;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Remove `Select a Template` option from user data and network data template dropdown.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Fixes # https://github.com/harvester/harvester/issues/4243

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->


### Screenshot/Video
<img width="1489" alt="Screenshot 2024-05-07 at 11 03 35 AM" src="https://github.com/harvester/dashboard/assets/5744158/3025d517-31c8-4e62-91b4-22a05231299d">
<img width="1487" alt="Screenshot 2024-05-07 at 11 03 48 AM" src="https://github.com/harvester/dashboard/assets/5744158/b6956678-a251-459d-8314-5a0d8acfcf61">
