### PR TITLE
Disable Save button when vGPU type is empty

### DIFF
--- a/pkg/harvester/dialog/EnableVGpuDevice.vue
+++ b/pkg/harvester/dialog/EnableVGpuDevice.vue
@@ -85,7 +85,7 @@ export default {
           {{ t('generic.cancel') }}
         </button>
 
-        <AsyncButton mode="edit" @click="save" />
+        <AsyncButton mode="edit" :disabled="!type" @click="save" />
       </div>
     </template>
   </Card>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related issue https://github.com/harvester/harvester/issues/5775
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

It disables the save button if vGpu type is empty.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

1- Navigate to vGPU Devices
2- Select a vGPU with missing vGPU type
3- Click Enable
4- The save button should be disabled

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

vGPU devices tab

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/harvester/dashboard/assets/26394656/82e6230a-ce57-4da4-9af6-b04b92182229)
