### PR TITLE
Remove pc-q35 machine type option

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -109,9 +109,6 @@ export default {
       }, {
         label: 'q35',
         value: 'q35'
-      }, {
-        label: 'pc-q35',
-        value: 'pc-q35'
       }];
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
According to the issue discussion [q35 is alias for always the latest pc-q35-version supported by version of qemu](https://github.com/harvester/harvester/issues/5437#issuecomment-2103748513).  

Remove `pc-q35` machine type option on GUI.


**Steps to reproduce the behavior:**
1. Navigate to `VM create page` -> `Advance options`
2. Create VM vm1 with machine type `pc-q35`


Note. this change needs to backport to 
- release-harvester-v1.3
- release-harvester-v1.2

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is:

Fixes # https://github.com/harvester/harvester/issues/5437

### Screenshot/Video
<img width="1480" alt="Screenshot 2024-05-13 at 11 29 52 AM" src="https://github.com/harvester/dashboard/assets/5744158/01bb1ace-31c4-430b-90f8-fe7afc790b7c">
