### PR TITLE
Start the checkbox text in capital letters

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -55,7 +55,7 @@ harvester:
     cloneVM:
       title: Clone VM
       name: New VM Name
-      type: clone volume data
+      type: Clone volume data
       action:
         create: Create
         clone: Clone


### PR DESCRIPTION
The checkbox text is not starting with an upper case. This PR is fixing that issue.

![image](https://github.com/harvester/dashboard/assets/1897962/02fc1cf4-71ef-4ad7-9286-93557a6476b4)


# Test plan:

## Case 1
1. Select the `Clone` action menu on any existing VM.
2. In the displayed dialog, the `Clone volume data` text of the checkbox must start with an upper case character.