### PR TITLE
Filter out witness node when creating storage network

### DIFF
--- a/pkg/harvester/models/network.harvesterhci.io.clusternetwork.js
+++ b/pkg/harvester/models/network.harvesterhci.io.clusternetwork.js
@@ -43,7 +43,8 @@ export default class HciClusterNetwork extends HarvesterResource {
   get nodes() {
     const nodes = this.$rootGetters[`${ this.inStore }/all`](NODE);
 
-    return nodes.filter(n => !n.isUnSchedulable);
+    // filter out witness nodes and unschedulable nodes
+    return nodes.filter(n => !n.isUnSchedulable && n.isEtcd !== 'true');
   }
 
   get vlanStatuses() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
When creating storage network in settings, if there exists witness node, we should filter them out by checking 
```
metadata.labels['node-role.harvesterhci.io/witness']
```


#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Vicente-Cheng 

Fixes #
[[BUG] can not config storage network through UI settings](https://github.com/harvester/harvester/issues/5741)



### Screenshot/Video
![Recording 2024-05-22 at 18 23 19](https://github.com/harvester/dashboard/assets/5744158/b4106376-e961-4849-a448-b6bb8e136a64)

