### PR TITLE
Filter out witness node when creating cluster network config

### DIFF
--- a/pkg/harvester/edit/network.harvesterhci.io.vlanconfig/index.vue
+++ b/pkg/harvester/edit/network.harvesterhci.io.vlanconfig/index.vue
@@ -92,7 +92,7 @@ export default {
       const inStore = this.$store.getters['currentProduct'].inStore;
       const nodes = this.$store.getters[`${ inStore }/all`](NODE);
 
-      return nodes.map((node) => {
+      return nodes.filter(n => n.isEtcd !== 'true').map((node) => {
         return {
           label: node.nameDisplay,
           value: node.id
@@ -213,7 +213,7 @@ export default {
       const inStore = this.$store.getters['currentProduct'].inStore;
       const nodes = this.$store.getters[`${ inStore }/all`](NODE);
 
-      return nodes;
+      return nodes.filter(n => n.isEtcd !== 'true');
     },
   },
 

--- a/pkg/harvester/models/network.harvesterhci.io.vlanconfig.js
+++ b/pkg/harvester/models/network.harvesterhci.io.vlanconfig.js
@@ -116,7 +116,7 @@ export default class HciVlanConfig extends HarvesterResource {
   }
 
   get nodes() {
-    return this.selectedNodes.filter(n => !n.isUnSchedulable);
+    return this.selectedNodes.filter(n => !n.isUnSchedulable && n.isEtcd !== 'true');
   }
 
   get stateDisplay() {


### PR DESCRIPTION
### Summary

Per discussed with @Vicente-Cheng , we should filter out `witness node` when creating cluster rnetwork config.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Vicente-Cheng 

Fixes #

[[BUG] Unable to select NIC to create network config when cluster contains witness node](https://github.com/harvester/harvester/issues/5325)


### Screenshot/Video
**1 default + 1 witness node**
![fix](https://github.com/harvester/dashboard/assets/5744158/347d35be-877e-4e7b-ab2f-4a785496b36e)

**2 default  + 1 witness node**
![env](https://github.com/harvester/dashboard/assets/5744158/8730b881-f65b-4929-93a2-e7d1eab68cb7)

![22](https://github.com/harvester/dashboard/assets/5744158/5a914a47-9ad1-4a9c-b9da-d13e7268d12c)

