### PR TITLE
Expose kubeconfig ttl setting in Harvester

### DIFF
--- a/pkg/harvester/config/settings.js
+++ b/pkg/harvester/config/settings.js
@@ -30,7 +30,8 @@ export const HCI_SETTING = {
   CSI_DRIVER_CONFIG:                      'csi-driver-config',
   VM_TERMINATION_PERIOD:                  'default-vm-termination-grace-period-seconds',
   NTP_SERVERS:                            'ntp-servers',
-  AUTO_ROTATE_RKE2_CERTS:                 'auto-rotate-rke2-certs'
+  AUTO_ROTATE_RKE2_CERTS:                 'auto-rotate-rke2-certs',
+  KUBECONFIG_DEFAULT_TOKEN_TTL_MINUTES:   'kubeconfig-default-token-ttl-minutes'
 };
 
 export const HCI_ALLOWED_SETTINGS = {
@@ -81,6 +82,7 @@ export const HCI_ALLOWED_SETTINGS = {
   [HCI_SETTING.NTP_SERVERS]:           {
     kind: 'json', from: 'import', canReset: true
   },
+  [HCI_SETTING.KUBECONFIG_DEFAULT_TOKEN_TTL_MINUTES]: {},
 };
 
 export const HCI_SINGLE_CLUSTER_ALLOWED_SETTING = {

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1360,6 +1360,7 @@ advancedSettings:
     'harv-default-vm-termination-grace-period-seconds': Config the VM termination grace period for VM stop.
     'harv-ntp-servers': Configure NTP server. You can configure multiple IPv4 addresses or host addresses.
     'harv-auto-rotate-rke2-certs': The certificate rotation mechanism relies on Rancher. Harvester will automatically update certificates generation to trigger rotation.
+    'harv-kubeconfig-default-token-ttl-minutes': 'TTL (in minutes) applied on Harvester admin kubeconfig files. Default is 0, which means to never expire.'
 
 typeLabel:
   kubevirt.io.virtualmachine: |-

--- a/pkg/harvester/l10n/zh-hans.yaml
+++ b/pkg/harvester/l10n/zh-hans.yaml
@@ -1288,6 +1288,7 @@ advancedSettings:
     'harv-release-download-url': 此设置用于配置<code>升级版本下载</code>的 URL 地址。Harvester 将从该 URL 托管的 (<code>$URL</code>/<code>$VERSION</code>/version.yaml) 文件中获取 ISO URL 和校验和值。
     'harv-default-vm-termination-grace-period-seconds': 配置停止虚拟机的终止宽限期。
     'harv-ntp-servers': 配置 NTP 服务器。你可以配置多个 IPv4 地址或主机地址。
+    'harv-kubeconfig-default-token-ttl-minutes': 'Harvester的管理kubeconfig文件有一个TTL（单位：分钟）参数，用来设置该文件经过多长时间失效过期。默认值是0，意味着永不过期。'
 
 typeLabel:
   kubevirt.io.virtualmachine: |-


### PR DESCRIPTION
Rancher 2.8.x introduced a new setting for kubeconfig ttl. The default value for the setting is 30 days. As a result admin kubeconfig generated from Harvester expires in 30 days since this leverages the embedded rancher.

This PR provides the UI part for https://github.com/harvester/harvester/pull/5896

### Fixes
https://github.com/harvester/harvester/issues/5977

### Screenshot/Video
![Bildschirmfoto vom 2024-06-04 13-04-30](https://github.com/harvester/dashboard/assets/1897962/3e9c319a-29ff-431a-a68f-0c679f8a7ba9)

![Bildschirmfoto vom 2024-06-04 13-04-44](https://github.com/harvester/dashboard/assets/1897962/934681be-a117-44a4-984b-ad3fc2f748e1)
