### PR TITLE
The `Labels` title is displayed twice in the `Host` labels page

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.host/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/index.vue
@@ -649,7 +649,6 @@ export default {
             :value="filteredLabels"
             :add-label="t('labels.addLabel')"
             :mode="mode"
-            :title="t('labels.labels.title')"
             :read-allowed="false"
             :value-can-be-empty="true"
             @input="updateHostLabels"


### PR DESCRIPTION
### Summary
Remove one of the duplicate title.

Before:
![labels_before](https://github.com/harvester/dashboard/assets/1897962/748d4510-315a-42c3-a56a-d47983dc503f)

After:
![labels_after](https://github.com/harvester/dashboard/assets/1897962/183702ce-1188-4c58-bb4b-38312307530b)

Fixes #
https://github.com/harvester/harvester/issues/5973

### Occurred changes and/or fixed issues
Remove the useless `:title` property which is responsible for the duplicate title.
