### PR TITLE
Add `Labels` tab to `Virtual Machines` resource page

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -825,6 +825,7 @@ export default {
           :mode="mode"
           :read-allowed="false"
           :value-can-be-empty="true"
+          :description="t(`harvester.virtualMachine.labels.description`)"
           @input="value.setLabels($event)"
         />
       </Tab>
@@ -841,6 +842,7 @@ export default {
           :display-side-by-side="false"
           :show-annotations="false"
           :show-label-title="false"
+          :label-description="t(`harvester.virtualMachine.instanceLabels.description`)"
         >
           <template #labels="{toggler}">
             <KeyValue

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -812,6 +812,51 @@ export default {
           </span>
         </Banner>
       </Tab>
+
+      <Tab
+        name="labels"
+        :label="t('generic.labels')"
+        :weight="-98"
+      >
+        <KeyValue
+          key="labels"
+          :value="value.labels"
+          :add-label="t('labels.addLabel')"
+          :mode="mode"
+          :read-allowed="false"
+          :value-can-be-empty="true"
+          @input="value.setLabels($event)"
+        />
+      </Tab>
+
+      <Tab
+        name="instanceLabel"
+        :label="t('harvester.tab.instanceLabel')"
+        :weight="-99"
+      >
+        <Labels
+          :default-container-class="'labels-and-annotations-container'"
+          :value="value"
+          :mode="mode"
+          :display-side-by-side="false"
+          :show-annotations="false"
+          :show-label-title="false"
+        >
+          <template #labels="{toggler}">
+            <KeyValue
+              key="labels"
+              :value="value.instanceLabels"
+              :protected-keys="value.systemLabels || []"
+              :toggle-filter="toggler"
+              :add-label="t('labels.addLabel')"
+              :mode="mode"
+              :read-allowed="false"
+              :value-can-be-empty="true"
+              @input="value.setInstanceLabels($event)"
+            />
+          </template>
+        </Labels>
+      </Tab>
     </Tabbed>
 
     <RestartVMDialog

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -728,6 +728,10 @@ harvester:
         inNamespaces: "Workloads in these namespaces"
       namespaces:
         label: Namespaces
+    labels:
+      description: ""
+    instanceLabels:
+      description: These labels are automatically synchronized to the Virtual Machine instance.
 
   volume:
     label: Volumes

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -251,6 +251,10 @@ export default {
       default: false,
       type:    Boolean
     },
+    description: {
+      default: '',
+      type:    String,
+    },
   },
   data() {
     const rows = this.getRows(this.value);
@@ -564,6 +568,11 @@ export default {
           />
         </h3>
       </slot>
+    </div>
+    <div v-if="description">
+      <p class="mt-10 mb-10">
+        {{ description }}
+      </p>
     </div>
     <div
       class="kv-container"

--- a/shell/components/form/Labels.vue
+++ b/shell/components/form/Labels.vue
@@ -53,6 +53,16 @@ export default {
       type:    Boolean,
       default: true,
     },
+
+    showLabelDescription: {
+      type:    Boolean,
+      default: true,
+    },
+
+    labelDescription: {
+      type:    String,
+      default: '',
+    },
   },
 
   data() {
@@ -89,8 +99,15 @@ export default {
             :on-label="t('labels.labels.show')"
           />
         </div>
-        <p class="mt-10 mb-10">
-          <t k="labels.labels.description" />
+        <p
+          v-if="showLabelDescription"
+          class="mt-10 mb-10"
+        >
+          <span v-if="labelDescription">{{ labelDescription }}</span>
+          <t
+            v-if="!labelDescription"
+            k="labels.labels.description"
+          />
         </p>
         <div :class="columnsClass">
           <slot


### PR DESCRIPTION
### Summary
Allow the user to manage the labels of a Virtual Machine resource via UI. Right now it is only possible to manage instance labels that are synced from the VM to the VMI resource.

Fixes #https://github.com/harvester/harvester/issues/5974

### Screenshot/Video
![grafik](https://github.com/user-attachments/assets/43a63b15-6bdf-43f0-9a3b-911e07ea4868)

![grafik](https://github.com/harvester/harvester/assets/1897962/547eefbc-3370-4f5c-ba02-043c1154360c)
