### PR TITLE
UI: allow all URL schemas for custom console URLs

### DIFF
--- a/pkg/harvester/models/harvester/node.js
+++ b/pkg/harvester/models/harvester/node.js
@@ -134,8 +134,9 @@ export default class HciNode extends HarvesterResource {
 
   get consoleUrl() {
     const url = this.metadata?.annotations?.[HCI_ANNOTATIONS.HOST_CONSOLE_URL];
+    const validator = /^[a-z]+:\/\//;
 
-    if (!url) {
+    if ((!url) || (url.match(validator) === null)) {
       return false;
     }
 

--- a/pkg/harvester/models/harvester/node.js
+++ b/pkg/harvester/models/harvester/node.js
@@ -136,7 +136,7 @@ export default class HciNode extends HarvesterResource {
     const url = this.metadata?.annotations?.[HCI_ANNOTATIONS.HOST_CONSOLE_URL];
     const validator = /^[a-z]+:\/\//;
 
-    if ((!url) || (url.match(validator) === null)) {
+    if (!url?.match(validator)) {
       return false;
     }
 

--- a/pkg/harvester/models/harvester/node.js
+++ b/pkg/harvester/models/harvester/node.js
@@ -139,10 +139,6 @@ export default class HciNode extends HarvesterResource {
       return false;
     }
 
-    if (!url.startsWith('http://') && !url.startsWith('https://')) {
-      return `http://${ url }`;
-    }
-
     return url;
   }
 


### PR DESCRIPTION
Allow all URL schemas for custom console URLs. This change removes a check that enforces the 'Console' button of a Harvester node to only redirect to URLs starting with `http://` or `https://`. Otherwise it will prepend `http://` to the configured URL. This breaks non-HTTP URL schemas like `vnc://` or `rtsx://`, which are sometimes used to launch custom VNC viewers instead of using the built-in one.

fixes: https://github.com/harvester/harvester/issues/6042

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug? No.
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1? No.
- Are backend engineers aware of UI changes? No backend change associated with this fix.

Related Issue #
https://github.com/harvester/harvester/issues/6042

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->