### PR TITLE
Fix undefined save error when editing witness node labels

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.host/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/index.vue
@@ -505,7 +505,9 @@ export default {
         }
       };
 
-      await retrySave();
+      if (this.longhornNode) {
+        await retrySave();
+      }
     },
   },
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Since witness node doesn't have CRD `nodes.longhorn.io`.  [longhornNode()](https://github.com/a110605/harvester-dashboard/blob/5ac7d8e4b061ba69b304703fbfc5f01e0f842154/pkg/harvester/edit/harvesterhci.io.host/index.vue#L213) got `undefined`. Skip  saveLonghornNode if longhornNodes is undefined to avoid error.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Vicente-Cheng 

Related Issue #
<!-- Define findings related to the feature or bug issue. -->
https://github.com/harvester/harvester/issues/5326

### Screenshot/Video
**harvester-node-1 is witness node.**

<img width="1066" alt="image" src="https://github.com/harvester/dashboard/assets/5744158/2f0850e4-d2ec-40bf-90b6-6b05eb3f5b72">

![123](https://github.com/harvester/dashboard/assets/5744158/9b8cfb97-1863-4e51-b200-a63809dbe6bf)

