### PR TITLE
Fix non-matched rule show matched nodes in create cluster network page

### DIFF
--- a/pkg/harvester/edit/network.harvesterhci.io.vlanconfig/index.vue
+++ b/pkg/harvester/edit/network.harvesterhci.io.vlanconfig/index.vue
@@ -286,7 +286,6 @@ export default {
         matchNICs = allNICs.filter(n => matchNodes.includes(n.nodeName));
         commonNodes = matchNodes.map(n => n.id);
       }
-
       this.matchNICs = this.intersection(matchNICs, commonNodes) || [];
     }, 250, { leading: true }),
 
@@ -314,12 +313,21 @@ export default {
       } else if (selector[HOSTNAME] && Object.keys(selector).length === 1) {
         const matchNode = allNodes.find(n => n.id === selector[HOSTNAME]);
 
-        this.matchingNodes = {
-          matched: 1,
-          total:   allNodes.length,
-          none:    false,
-          sample:  matchNode ? matchNode.nameDisplay : selector[HOSTNAME],
-        };
+        if (matchNode) {
+          this.matchingNodes = {
+            matched: 1,
+            total:   allNodes.length,
+            none:    false,
+            sample:  matchNode.nameDisplay,
+          };
+        } else {
+          this.matchingNodes = {
+            matched: 0,
+            total:   0,
+            none:    true,
+            sample:  null,
+          };
+        }
       } else {
         const match = matching(allNodes, selector);
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
When users choose the third node selector, if input non matched rule, we should show zero match.

Since we remove witness node from [previous PR](https://github.com/harvester/dashboard/pull/1031), if user input rule 
```
kubernetes.io/hostname : harvester-node-1
```

we should show zero match.


We should also NOT show any match node if user input non-existed kubernete.io/hostname

![Screenshot_20240703_215957](https://github.com/harvester/dashboard/assets/5744158/71f0a69d-4d67-4fa9-908a-2277c90c4387)


#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
https://github.com/harvester/harvester/issues/5325


### Screenshot/Video
After fix
![Recording 2024-07-03 at 21 55 33](https://github.com/harvester/dashboard/assets/5744158/27df3d21-baca-437a-b72c-321c2a3f87cb)
