### PR TITLE
Remove `harvesterhci.io/owned-by`

### DIFF
--- a/pkg/harvester/config/labels-annotations.js
+++ b/pkg/harvester/config/labels-annotations.js
@@ -1,7 +1,6 @@
 export const HCI = {
   CLOUD_INIT:                   'harvesterhci.io/cloud-init-template',
   CURRENT_IP:                   'rke2.io/internal-ip',
-  OWNED_BY:                     'harvesterhci.io/owned-by',
   IMAGE_ID:                     'harvesterhci.io/imageId',
   SSH_NAMES:                    'harvesterhci.io/sshNames',
   NETWORK_IPS:                  'network.harvesterhci.io/ips',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue https://github.com/harvester/harvester/issues/5905
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- We are removing `harvesterhci.io/owned-by` label from UI.
- Attached VM is now calculated by iterating through the VMs volume list -> `vm.spec.template.spec.volumes`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->