### PR TITLE
Hide `AbortMigration` button

### DIFF
--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -170,13 +170,13 @@ export default class VirtVm extends HarvesterResource {
       },
       {
         action:  'migrateVM',
-        enabled: !!this.actions?.migrate,
+        enabled: !!this.actions?.migrate && !this.vmi?.vmimResource,
         icon:    'icon icon-copy',
         label:   this.t('harvester.action.migrate')
       },
       {
         action:  'abortMigrationVM',
-        enabled: !!this.actions?.abortMigration,
+        enabled: !!this.actions?.abortMigration && !!this.vmi?.vmimResource,
         icon:    'icon icon-close',
         label:   this.t('harvester.action.abortMigration')
       },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue https://github.com/harvester/harvester/issues/6193
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

When users abort a VM's migration, Harvester deletes the VM's `virtualmachineinstancemigrations.kubevirt.io` but it is not updating the `virtualmachine.kubevirt.io` object.
This means the UI is not receiving a new VM resource version from WS, where the AbortMigration action is removed from the actions list.

This changes will enforce the migrate/abort buttons visibility checks by looking at the status of VM's `virtualmachineinstancemigrations.kubevirt.io`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->