### PR TITLE
fix: honor annotation matchNodes from network config to show selected nodes in detail page

### DIFF
--- a/pkg/harvester/config/labels-annotations.js
+++ b/pkg/harvester/config/labels-annotations.js
@@ -25,6 +25,7 @@ export const HCI = {
   INIT_IP:                      'etcd.rke2.cattle.io/node-address',
   NODE_SCHEDULABLE:             'kubevirt.io/schedulable',
   NETWORK_ROUTE:                'network.harvesterhci.io/route',
+  MATCHED_NODES:                'network.harvesterhci.io/matched-nodes',
   OS_UPGRADE_IMAGE:             'harvesterhci.io/os-upgrade-image',
   LATEST_UPGRADE:               'harvesterhci.io/latestUpgrade',
   UPGRADE_STATE:                'harvesterhci.io/upgradeState',

--- a/pkg/harvester/detail/network.harvesterhci.io.vlanconfig.vue
+++ b/pkg/harvester/detail/network.harvesterhci.io.vlanconfig.vue
@@ -8,6 +8,7 @@ import { STATE, NAME, AGE } from '@shell/config/table-headers';
 import { matching } from '@shell/utils/selector';
 import { NODE } from '@shell/config/types';
 import { isEmpty } from '@shell/utils/object';
+import { HCI } from '@pkg/harvester/config/labels-annotations';
 
 export default {
   components: {
@@ -55,10 +56,13 @@ export default {
       const inStore = this.$store.getters['currentProduct'].inStore;
 
       const nodes = this.$store.getters[`${ inStore }/all`](NODE);
+      const matchedNodes = this.value?.metadata?.annotations?.[HCI.MATCHED_NODES];
       const selector = this.value?.spec?.nodeSelector;
 
       if (!isEmpty(selector)) {
         return matching(nodes, selector);
+      } else if (matchedNodes && matchedNodes.length > 0) {
+        return nodes.filter(node => matchedNodes.includes(node.id));
       } else {
         return nodes;
       }


### PR DESCRIPTION
### Summary

Per discussion this [comment](https://github.com/harvester/harvester/issues/5325#issuecomment-2236668074) with team, we decide to filter out witness node from backend annotation when creating network config via `select all nodes`.

Frontend only honors annoation `network.harvesterhci.io/matched-nodes` to show selected nodes in page.

Note. we will have backend PR to filter out witness node in `annotaton.network.harvesterhci.io/matched-nodes`.


#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Vicente-Cheng 



Note. this PR needs backport to v1.3.1 and v1.4

Related Issue #
https://github.com/harvester/harvester/issues/5325

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->





### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
![Screenshot_20240726_123218](https://github.com/user-attachments/assets/980066f2-b453-4964-a146-1d21cc1e8eef)
