### PR TITLE
Allow user to enable / disable node disk scheduling

### DIFF
--- a/pkg/harvester/detail/harvesterhci.io.host/HarvesterHostDisk.vue
+++ b/pkg/harvester/detail/harvesterhci.io.host/HarvesterHostDisk.vue
@@ -4,13 +4,15 @@ import LabelValue from '@shell/components/LabelValue';
 import { BadgeState } from '@components/BadgeState';
 import { Banner } from '@components/Banner';
 import HarvesterDisk from '../../mixins/harvester-disk';
+import { RadioGroup } from '@components/Form/Radio';
 
 export default {
   components: {
     LabelValue,
     BadgeState,
     Banner,
-    Tag
+    Tag,
+    RadioGroup
   },
 
   mixins: [
@@ -37,6 +39,18 @@ export default {
     return {};
   },
   computed: {
+    targetDisk() {
+      return this.disks.find(disk => disk.name === this.value.name);
+    },
+    schedulableTooltipMessage() {
+      const { name, path } = this.value;
+
+      if (this.targetDisk && !this.targetDisk.allowScheduling && name && path) {
+        return this.t('harvester.host.disk.allowScheduling.tooltip', { name, path });
+      } else {
+        return this.schedulableCondition.message;
+      }
+    },
     allowSchedulingOptions() {
       return [{
         label: this.t('generic.enabled'),
@@ -117,6 +131,16 @@ export default {
       </div>
       <div class="row mt-10">
         <div class="col span-12">
+          <div class="pull-left">
+            <RadioGroup
+              v-model="value.allowScheduling"
+              name="diskScheduling"
+              :label="t('harvester.host.disk.allowScheduling.label')"
+              :mode="mode"
+              :options="allowSchedulingOptions"
+              :row="true"
+            />
+          </div>
           <div class="pull-right">
             {{ t('harvester.host.disk.conditions') }}:
             <BadgeState
@@ -127,9 +151,9 @@ export default {
               class="mr-10 ml-10 state"
             />
             <BadgeState
-              v-clean-tooltip="schedulableCondition.message"
-              :color="schedulableCondition.status === 'True' ? 'bg-success' : 'bg-error' "
-              :icon="schedulableCondition.status === 'True' ? 'icon-checkmark' : 'icon-warning' "
+              v-clean-tooltip="schedulableTooltipMessage"
+              :color="schedulableCondition.status === 'True' && targetDisk?.allowScheduling ? 'bg-success' : 'bg-error' "
+              :icon="schedulableCondition.status === 'True' && targetDisk?.allowScheduling ? 'icon-checkmark' : 'icon-warning' "
               label="Schedulable"
               class="mr-10 state"
             />

--- a/pkg/harvester/edit/harvesterhci.io.host/HarvesterDisk.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/HarvesterDisk.vue
@@ -44,6 +44,18 @@ export default {
     return {};
   },
   computed: {
+    targetDisk() {
+      return this.disks.find(disk => disk.name === this.value.name);
+    },
+    schedulableTooltipMessage() {
+      const { name, path } = this.value;
+
+      if (this.targetDisk && !this.targetDisk.allowScheduling && name && path) {
+        return this.t('harvester.host.disk.allowScheduling.tooltip', { name, path });
+      } else {
+        return this.schedulableCondition.message;
+      }
+    },
     allowSchedulingOptions() {
       return [{
         label: this.t('generic.enabled'),
@@ -181,6 +193,16 @@ export default {
       </div>
       <div class="row mt-10">
         <div class="col span-12">
+          <div class="pull-left">
+            <RadioGroup
+              v-model="value.allowScheduling"
+              name="diskScheduling"
+              :label="t('harvester.host.disk.allowScheduling.label')"
+              :mode="mode"
+              :options="allowSchedulingOptions"
+              :row="true"
+            />
+          </div>
           <div class="pull-right">
             {{ t('harvester.host.disk.conditions') }}:
             <BadgeState
@@ -191,9 +213,9 @@ export default {
               class="mr-10 ml-10 state"
             />
             <BadgeState
-              v-clean-tooltip="schedulableCondition.message"
-              :color="schedulableCondition.status === 'True' ? 'bg-success' : 'bg-error' "
-              :icon="schedulableCondition.status === 'True' ? 'icon-checkmark' : 'icon-warning' "
+              v-clean-tooltip="schedulableTooltipMessage"
+              :color="schedulableCondition.status === 'True' && targetDisk?.allowScheduling ? 'bg-success' : 'bg-error' "
+              :icon="schedulableCondition.status === 'True' && targetDisk?.allowScheduling ? 'icon-checkmark' : 'icon-warning' "
               label="Schedulable"
               class="mr-10 state"
             />

--- a/pkg/harvester/edit/harvesterhci.io.host/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/index.vue
@@ -478,10 +478,11 @@ export default {
 
       const disks = this.longhornNode?.spec?.disks || {};
 
+      // update each disk tags and scheduling
       this.newDisks.map((disk) => {
         (disks[disk.name] || {}).tags = disk.tags;
+        (disks[disk.name] || {}).allowScheduling = disk.allowScheduling;
       });
-
       let count = 0;
 
       const retrySave = async() => {

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -400,6 +400,7 @@ harvester:
         label: Storage Reserved
       allowScheduling:
         label: Scheduling
+        tooltip: Disk {name} ({path}) scheduling is disabled
       evictionRequested:
         label: Eviction Requested
       forceFormatted:


### PR DESCRIPTION
### Summary
 - Allow user to enable / disable node disk scheduling in node page -> Edit Config -> storage tab.
 - View the disk scheduling in node detail page storage tab.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Vicente-Cheng

Related Issue #
https://github.com/harvester/harvester/issues/5836

### Areas which could experience regressions
This PR should be backport to v1.4 and v1.3

### Screenshot/Video


https://github.com/user-attachments/assets/8957120b-e520-4e97-912a-6af53462bf0d


