### PR TITLE
[Backport v1.4] fix: vlan id input mask

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
+++ b/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
@@ -143,10 +143,12 @@ export default {
     },
 
     input(neu) {
-      const pattern = /^([1-9]|[1-9][0-9]{1,2}|[1-3][0-9]{3}|40[0-9][0-4])$/;
-
-      if (!pattern.test(neu) && neu !== '') {
-        this.config.vlan = neu > 4094 ? 4094 : 1;
+      if (!isNaN(neu)) {
+        if (neu > 0 && neu < 4095) {
+          this.config.vlan = neu;
+        } else {
+          this.config.vlan = neu > 4094 ? 4094 : 1;
+        }
       }
     },
 


### PR DESCRIPTION
Fix number validation logic in VLAN ID input mask in the VM network creation/edit dialogue to allow input of any number between 1 and 4094, as intended.
The new logic does away with regex and just checks if the input value is number-like and within the allowed range. For any number-like outside the range, the input is clamped to the closest value within the range.

related-to: https://jira.suse.com/browse/SURE-8851
related-to: https://github.com/harvester/harvester/issues/6290
related-to: https://github.com/harvester/dashboard/pull/1093