### PR TITLE
Fix vlan id should be integer type

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
+++ b/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
@@ -143,12 +143,19 @@ export default {
     },
 
     input(neu) {
-      if (!isNaN(neu)) {
-        if (neu > 0 && neu < 4095) {
-          this.config.vlan = neu;
-        } else {
-          this.config.vlan = neu > 4094 ? 4094 : 1;
-        }
+      if (neu === '') {
+        this.config.vlan = '';
+
+        return;
+      }
+      const newValue = Number(neu);
+
+      if (newValue > 4094) {
+        this.config.vlan = 4094;
+      } else if (newValue < 1) {
+        this.config.vlan = 1;
+      } else {
+        this.config.vlan = newValue;
       }
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- fix vlan id should be integer type
- allow user to modify vlan Id with empty value 
- ensure input value should between 1 ~ 4094 

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
- https://github.com/harvester/harvester/issues/6309
- https://github.com/harvester/harvester/issues/6290

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
Note. this PR should backport to v1.4 / v1.3 / v1.2


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

https://github.com/user-attachments/assets/1b8d6728-fb77-4f42-9b25-9f15b9c61baa

