### PR TITLE
feat: Add ability to enable Longhorn V2 Data Engine

### DIFF
--- a/pkg/harvester/components/SettingList.vue
+++ b/pkg/harvester/components/SettingList.vue
@@ -112,6 +112,9 @@ export default {
             <span v-if="setting.customized" class="modified">
               Modified
             </span>
+            <span v-if="setting.technicalPreview" v-clean-tooltip="t('advancedSettings.technicalPreview')" class="technical-preview">
+              Technical Preview
+            </span>
           </h1>
           <h2 v-clean-html="t(setting.description, {}, true)">
           </h2>
@@ -196,6 +199,14 @@ export default {
 .modified {
   margin-left: 10px;
   border: 1px solid var(--primary);
+  border-radius: 5px;
+  padding: 2px 10px;
+  font-size: 12px;
+}
+
+.technical-preview {
+  margin-left: 10px;
+  border: 1px solid var(--warning);
   border-radius: 5px;
   padding: 2px 10px;
   font-size: 12px;

--- a/pkg/harvester/config/settings.js
+++ b/pkg/harvester/config/settings.js
@@ -84,7 +84,7 @@ export const HCI_ALLOWED_SETTINGS = {
     kind: 'json', from: 'import', canReset: true
   },
   [HCI_SETTING.KUBECONFIG_DEFAULT_TOKEN_TTL_MINUTES]: {},
-  [HCI_SETTING.LONGHORN_V2_DATA_ENGINE_ENABLED]:      { kind: 'boolean' },
+  [HCI_SETTING.LONGHORN_V2_DATA_ENGINE_ENABLED]:      { kind: 'boolean', technicalPreview: true },
 };
 
 export const HCI_SINGLE_CLUSTER_ALLOWED_SETTING = {

--- a/pkg/harvester/config/settings.js
+++ b/pkg/harvester/config/settings.js
@@ -31,7 +31,8 @@ export const HCI_SETTING = {
   VM_TERMINATION_PERIOD:                  'default-vm-termination-grace-period-seconds',
   NTP_SERVERS:                            'ntp-servers',
   AUTO_ROTATE_RKE2_CERTS:                 'auto-rotate-rke2-certs',
-  KUBECONFIG_DEFAULT_TOKEN_TTL_MINUTES:   'kubeconfig-default-token-ttl-minutes'
+  KUBECONFIG_DEFAULT_TOKEN_TTL_MINUTES:   'kubeconfig-default-token-ttl-minutes',
+  LONGHORN_V2_DATA_ENGINE_ENABLED:        'longhorn-v2-data-engine-enabled',
 };
 
 export const HCI_ALLOWED_SETTINGS = {
@@ -83,6 +84,7 @@ export const HCI_ALLOWED_SETTINGS = {
     kind: 'json', from: 'import', canReset: true
   },
   [HCI_SETTING.KUBECONFIG_DEFAULT_TOKEN_TTL_MINUTES]: {},
+  [HCI_SETTING.LONGHORN_V2_DATA_ENGINE_ENABLED]:      { kind: 'boolean' },
 };
 
 export const HCI_SINGLE_CLUSTER_ALLOWED_SETTING = {

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1339,6 +1339,7 @@ harvester:
       placeholder: 'topology.kubernetes.io/zone'
 
 advancedSettings:
+  technicalPreview: 'Technical Previews allow users to test and evaluate early-access functionality prior to official supported releases'
   descriptions:
     'harv-vlan': Default Network Interface name of the VLAN network.
     'harv-backup-target': Custom backup target to store VM backups.
@@ -1370,7 +1371,7 @@ advancedSettings:
     'harv-ntp-servers': Configure NTP server. You can configure multiple IPv4 addresses or host addresses.
     'harv-auto-rotate-rke2-certs': The certificate rotation mechanism relies on Rancher. Harvester will automatically update certificates generation to trigger rotation.
     'harv-kubeconfig-default-token-ttl-minutes': 'TTL (in minutes) applied on Harvester admin kubeconfig files. Default is 0, which means to never expire.'
-    'harv-longhorn-v2-data-engine-enabled': 'Enable the Longhorn V2 data engine. Default is false. <ul><li>Changing this setting will restart RKE2 on all nodes. This will not affect running VM workloads.</li><li>If you see "not enough hugepages-2Mi capacity" errors when enabling this setting, wait a minute for the error to clear. If the error remains, reboot the affected node.</li><li>WARNING: THIS IS A PREVIEW FEATURE</li></ul>'
+    'harv-longhorn-v2-data-engine-enabled': 'Enable the Longhorn V2 data engine. Default is false. <ul><li>Changing this setting will restart RKE2 on all nodes. This will not affect running VM workloads.</li><li>If you see "not enough hugepages-2Mi capacity" errors when enabling this setting, wait a minute for the error to clear. If the error remains, reboot the affected node.</li></ul>'
 
 typeLabel:
   kubevirt.io.virtualmachine: |-

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1370,6 +1370,7 @@ advancedSettings:
     'harv-ntp-servers': Configure NTP server. You can configure multiple IPv4 addresses or host addresses.
     'harv-auto-rotate-rke2-certs': The certificate rotation mechanism relies on Rancher. Harvester will automatically update certificates generation to trigger rotation.
     'harv-kubeconfig-default-token-ttl-minutes': 'TTL (in minutes) applied on Harvester admin kubeconfig files. Default is 0, which means to never expire.'
+    'harv-longhorn-v2-data-engine-enabled': 'Enable the Longhorn V2 data engine. Default is false. <ul><li>Changing this setting will restart RKE2 on all nodes. This will not affect running VM workloads.</li><li>If you see "not enough hugepages-2Mi capacity" errors when enabling this setting, wait a minute for the error to clear. If the error remains, reboot the affected node.</li><li>WARNING: THIS IS A PREVIEW FEATURE</li></ul>'
 
 typeLabel:
   kubevirt.io.virtualmachine: |-


### PR DESCRIPTION
Related issue: 
- https://github.com/harvester/harvester/issues/5274
- https://github.com/harvester/harvester/issues/5953

Note: this depends on https://github.com/harvester/harvester/pull/6405

Here's an example screenshot showing the setting with its description, along with the error message from Longhorn in the case where hugepages can't be allocated at runtime and a node needs rebooting:

![image](https://github.com/user-attachments/assets/934f949f-dc5c-49a0-a1e1-b163b7263bd9)

Should add more text explaining what "preview feature" means in this context? Links to external docs? Anything else?