### PR TITLE
[ui-strings] Consistent language use applied across UI strings

### DIFF
--- a/pkg/harvester/config/harvester-map.js
+++ b/pkg/harvester/config/harvester-map.js
@@ -23,7 +23,7 @@ export const InterfaceOption = [{
 
 export const SOURCE_TYPE = {
   NEW:           'New',
-  IMAGE:         'VM Image',
+  IMAGE:         'Virtual Machine Image',
   ATTACH_VOLUME: 'Existing Volume',
   CONTAINER:     'Container'
 };

--- a/pkg/harvester/config/harvester.js
+++ b/pkg/harvester/config/harvester.js
@@ -37,8 +37,8 @@ import {
 import { IF_HAVE } from '@shell/store/type-map';
 
 const TEMPLATE = HCI.VM_VERSION;
-const MONITORING_GROUP = 'Monitoring & Logging::Monitoring';
-const LOGGING_GROUP = 'Monitoring & Logging::Logging';
+const MONITORING_GROUP = 'Monitoring and Logging::Monitoring';
+const LOGGING_GROUP = 'Monitoring and Logging::Logging';
 
 export const PRODUCT_NAME = 'harvester';
 

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -134,7 +134,7 @@ harvester:
     launchFormTemplate: Launch instance from template
     modifyTemplate: Modify template (Create new version)
     setDefaultVersion: Set default version
-    addTemplateVersion: Add templateVersion
+    addTemplateVersion: Add template version
     backup: Take Backup
     restore: Restore
     restoreNewVM: Restore New
@@ -201,7 +201,7 @@ harvester:
     volume: Volume
     network: Network
     model: Model
-    macAddress: Mac address
+    macAddress: MAC address
     port: Port
     protocol: Protocol
     remove: Remove
@@ -370,7 +370,7 @@ harvester:
       ksmStatus: KSM Status
       modeOption:
         standard: Standard
-        high: High-Perfomanace
+        high: High-performance
         customized: Customized
       parameters:
         title: Ksmtuned Parameters
@@ -407,7 +407,7 @@ harvester:
         label: Eviction Requested
       forceFormatted:
         label: Force Formatted
-        toolTip: Force formatted will cleanup disk data, make sure you backup all available data to prevent data loss.
+        toolTip: Force formatted will clean up disk data, make sure you backup all available data to prevent data loss.
         yes: Yes (Ext4 File System)
       description:
         label: Description
@@ -440,8 +440,8 @@ harvester:
       tips: You can configure multiple IPv4 addresses or host addresses.
       placeholder: e.g. IPv4
       ntpSyncStatus:
-        isDisabled: 'The NTP is disabled. Please check the NTP service is active.'
-        isUnsynced: 'The time is not synchronized with the NTP server {current}.'
+        isDisabled: 'NTP is disabled. Please check the NTP service is active.'
+        isUnsynced: 'NTP is not synchronized with the NTP server {current}.'
 
   virtualMachine:
     label: Virtual Machines
@@ -471,7 +471,7 @@ harvester:
       version:
         label: Version
     console:
-      novnc: Open in Web VNC
+      novnc: Open in WebVNC
       serial: Open in Serial Console
     promptRemove:
       title: 'Select the volume you want to delete:'
@@ -554,7 +554,7 @@ harvester:
       network:
         label: Network Data Template
         title: "Network Data:"
-        tip: "The network-data configuration allows you to customize the instance’s networking interfaces by assigning subnet configuration, virtual device creation (bonds, bridges, vlans) routes and DNS configuration. <a href='https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-v1.html' target='_blank'>Learn more</a>"
+        tip: "The network-data configuration allows you to customize the instance’s networking interfaces by assigning subnet configuration, virtual device creation (bonds, bridges, VLANs) routes and DNS configuration. <a href='https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-v1.html' target='_blank'>Learn more</a>"
     scheduling:
       affinity:
         anyNode: 'Run virtual machine on any available node'
@@ -916,7 +916,7 @@ harvester:
 
     upgrade:
       selectExitImage: Please select the OS image to upgrade.
-      imageUrl: Please input a valid image url.
+      imageUrl: Please input a valid image URL.
       chooseFile: Please select to upload an image.
       checksum: Checksum
     harvesterMonitoring:
@@ -970,7 +970,7 @@ harvester:
     cidr:
       label: CIDR/IP Range
       invalid: '"CIDR/IP Range" is invalid.'
-      toolTip: "We can apply multiple pools or ranges by seperating them with commas. For example: 192.168.0.200/30,192.168.0.200/29 or 192.168.0.10-192.168.0.11"
+      toolTip: "We can apply multiple pools or ranges by separating them with commas. For example: 192.168.0.200/30,192.168.0.200/29 or 192.168.0.10-192.168.0.11"
     add:
       label: Add IP Pools
 
@@ -1349,7 +1349,7 @@ advancedSettings:
     'harv-server-version': Harvester server version.
     'harv-upgrade-checker-enabled': Specifies whether to enable Harvester upgrade check or not. Default is True.
     'harv-upgrade-checker-url': Default Harvester upgrade check url. Only used when the <code>upgrade-checker-enabled</code> is equal to True.
-    'harv-ui-source': Configuration for how to load the UI source.
+    'harv-ui-source': Configure how to load the UI source.
     'harv-ui-index': 'HTML index location for the UI.'
     'harv-ui-plugin-index': 'JS index location for the Harvester plugin UI.'
     'harv-cluster-registration-url': Registration URL for multi-cluster management.

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -10,10 +10,10 @@ generic:
 nav:
   group:
     networks: Networks
-    backupAndSnapshot: Backup & Snapshot
+    backupAndSnapshot: Backup and Snapshots
     Monitoring: Monitoring
     Logging: Logging
-    'Monitoring & Logging': Monitoring & Logging
+    'Monitoring and Logging': Monitoring and Logging
 
 resourceTable:
   groupBy:
@@ -28,7 +28,7 @@ members:
 
 asyncButton:
   restart:
-    action: Save & Restart
+    action: Save and Restart
     success: Restarted
     waiting: Restarting&hellip;
 
@@ -40,7 +40,7 @@ harvester:
       addBackup: Add Backup
     restore:
       success: 'Restore { name } created successfully.'
-      title: Backup and restore
+      title: Backup and Restore
       selectBackup: Select Backup
       message:
         backup: Please select the backup that needs to be restored.
@@ -53,16 +53,16 @@ harvester:
         success: 'Template { templateName } created successfully.'
         failed: 'Failed generated template!'
     cloneVM:
-      title: Clone VM
-      name: New VM Name
+      title: Clone Virtual Machine
+      name: New Virtual Machine Name
       type: Clone volume data
       action:
         create: Create
         clone: Clone
       message:
-        tip: Please enter a VM name!
-        success: 'VM { name } cloned successfully.'
-        failed: 'Failed clone VM!'
+        tip: Please enter a virtual machine name!
+        success: 'Virtual machine { name } cloned successfully.'
+        failed: 'Failed clone virtual machine!'
     exportImage:
       title: Export to Image
       name: Name
@@ -77,21 +77,21 @@ harvester:
           label: Target Node
           placeholder: Choose Target Node
     ejectCDROM:
-      title: Eject CDROM
+      title: Eject CD-ROM
       warnTip: Eject volume will restart the virtual machine.
       operationTip: 'Select the volume you want to delete:'
       delete: Delete
     bundle:
-      title: Generate Support Bundle
+      title: Generate a Support Bundle
       url: Issue URL
       description: Description
       requiredDesc: Description is required!
-      titleDescription: Collect system-related log in Harvester, to help with troubleshooting and support.
+      titleDescription: Collect system-related logs in Harvester to help with troubleshooting and support.
     hotplug:
-      success: 'Volume { diskName } is mounted to the VM { vm }.'
+      success: 'Volume { diskName } is mounted to the virtual machine { vm }.'
       title: Add Volume
     hotunplug:
-      success: 'Volume { name } is detach successfully.'
+      success: 'Volume { name } is detached successfully.'
     snapshot:
       title: Take Snapshot
       name: Name
@@ -109,10 +109,10 @@ harvester:
     vmSnapshot:
       title: Take VM Snapshot
       name: Name
-      success: 'Take VM Snapshot { name } successfully.'
+      success: 'Take virtual machine Snapshot { name } successfully.'
     restart:
-      title: Restart VM
-      tip: Restart the Virtual Machine now for configuration changes to take effect.
+      title: Restart Virtual Machine
+      tip: Restart the virtual machine for configuration changes to take effect.
       cancel: Save
   notification:
     title:
@@ -130,7 +130,7 @@ harvester:
     deepClone: Clone
     shallowClone: Clone Template
     unpause: Unpause
-    ejectCDROM: Eject CDROM
+    ejectCDROM: Eject CD-ROM
     launchFormTemplate: Launch instance from template
     modifyTemplate: Modify template (Create new version)
     setDefaultVersion: Set default version
@@ -152,7 +152,7 @@ harvester:
     cancelExpand: Cancel Expand
     snapshot: Take Snapshot
     pvcClone: Clone Volume
-    vmSnapshot: Take VM Snapshot
+    vmSnapshot: Take Virtual Machine Snapshot
     shutdown: Shut Down
     powerOn: Power On
     reboot: Reboot
@@ -163,13 +163,13 @@ harvester:
     progress: Progress
     message: Message
     phase: Phase
-    attachedVM: Attached VM
+    attachedVM: Attached Virtual Machine
     fingerprint: Fingerprint
     value: Value
     actions: Actions
     readyToUse: Ready To Use
     backupTarget: Backup Target
-    targetVm: Target VM
+    targetVm: Target Virtual Machine
     hostIp: Host IP
     vm:
       ipAddress: IP Address
@@ -177,7 +177,7 @@ harvester:
       defaultVersion: Default Version
     network:
       type: Type
-      vlan: Vlan ID
+      vlan: VLAN ID
     snapshotTargetVolume: Original Volume
     volumeSnapshotCounts: Snapshot Counts
     networkState: Network State
@@ -189,8 +189,8 @@ harvester:
     advanced: Advanced Options
     accessCredentials: Access Credentials
     pciDevices: PCI Devices
-    vGpuDevices: VGPU Devices
-    vmScheduling: VM Scheduling
+    vGpuDevices: vGPU Devices
+    vmScheduling: Virtual Machine Scheduling
     instanceLabel: Instance Labels
   fields:
     version: Version
@@ -201,24 +201,24 @@ harvester:
     volume: Volume
     network: Network
     model: Model
-    macAddress: Mac Address
+    macAddress: Mac address
     port: Port
     protocol: Protocol
-    remove: REMOVE
+    remove: Remove
     PhysicalNic: Physical NIC
-    cpu: Cpu
+    cpu: CPU
     memory: Memory
     virtualName: Virtual machine name
     promiscuous: Promiscuous
-    ipv4Address: IPv4 Address
-    filterLabels: Filter Labels
-    storageClass: Storage Class
-    dockerImage: Docker Image 
+    ipv4Address: IPv4 address
+    filterLabels: Filter labels
+    storageClass: Storage class
+    dockerImage: Docker image
   pci:
     available: Available Devices
     compatibleNodes: Compatible Nodes
     impossibleSelection: 'There are no hosts with all of the selected devices.'
-    howToUseDevice: 'Use the table below to enable PCI passthrough on each device you want to use in this VM.'
+    howToUseDevice: 'Use the table below to enable PCI passthrough on each device you want to use in this virtual machine.'
     deviceInTheSameHost: 'You can only select devices on the same host.'
     oldFormatDevices:
       help: |-
@@ -229,11 +229,11 @@ harvester:
           {oldFormatDevicesHTML}
         </ul>
         <p>
-          Please use the following instructions to update the VM:
+          Please use the following instructions to update the virtual machine:
         </p>
         <ol>
-          <li>Stop the VM, edit the VM YAML, and remove the <Code>hostDevices</Code> section, and save VM the changes to the YAML file.</li>
-          <li>Edit the VM, and add the already enabled PCIDevice from the list of available PCIDevices, and save and start VM.</li>
+          <li>Stop the virtual machine, edit the virtual machine YAML, and remove the <Code>hostDevices</Code> section, and save virtual machine the changes to the YAML file.</li>
+          <li>Edit the virtual machine, and add the already enabled PCI Device from the list of available PCIDevices, and save and start VM.</li>
         </ol>
     showCompatibility: Show device compatibility matrix
     hideCompatibility: Hide device compatibility matrix
@@ -242,12 +242,12 @@ harvester:
     cantUnclaim: You cannot disable passthrough on a device claimed by another user.
     enableGroup: Enable Group
     disableGroup: Disable Group
-    labelRequired: "This rule should not be manually altered: it ensures that the PCI devices selected for this virtual machine are available on the VM's host."
+    labelRequired: "This rule should not be manually altered: it ensures that the PCI devices selected for this virtual machine are available on the virtual machine's host."
     goSetting:
-      prefix: The pcidevices-controller addon is not enabled, click
+      prefix: The pcidevices-controller add-on is not enabled, click
       middle: here
       suffix: to enable it to manage your PCI devices.
-    noPCIPermission: Please contact system admin to enable the PCI devices first.
+    noPCIPermission: Please contact your system administrator to enable the PCI devices first.
     enablePassthroughWarning: Please be careful not to use host-owned PCI devices (e.g., management and VLAN NICs). Incorrect device allocation may cause damage to your cluster, including node failure.
     matrixHostName: Host Name
     matrixDeviceClaimName: Device Claim Name
@@ -300,7 +300,7 @@ harvester:
       events:
         label: Events
       vmMetrics:
-        label: VM Metrics
+        label: Virtual Machine Metrics
 
     version: Version
   host:
@@ -309,11 +309,11 @@ harvester:
     inconsistentIP: "Host IP is inconsistent, current IP: { currentIP }, initial IP: { initIP }"
     promote:
       none: ' '
-      running: promoting
-      failed: promote failed
-      unknown: promote halted
-      promoteRestart: restarting
-      promoteSucceed: promote completed
+      running: Promoting
+      failed: Promote failed
+      unknown: Promote halted
+      promoteRestart: Restarting
+      promoteSucceed: Promote completed
     tabs:
       network: Network
       overview: Overview
@@ -323,10 +323,10 @@ harvester:
       storage: Storage
       labels: Labels
       ksmtuned: Ksmtuned
-      seeder: Out-of-Band Access
+      seeder: Out-of-band Access
     detail:
       kvm:
-        disableMessage: Hardware-based virtualization is disabled or not supported. Hardware-based virtualization must be enabled before creating any Virtual Machines.
+        disableMessage: Hardware-based virtualization is disabled or not supported. Hardware-based virtualization must be enabled before creating any virtual machines.
       title:
         network: Network Configuration
       hostIP: Host IP
@@ -353,7 +353,7 @@ harvester:
     enableMaintenance:
       title: Enable Maintenance Mode
       protip: The operation will migrate all virtual machines on this node to other nodes.
-      shutDownVMs: Check <b>Force</b> option to shutdown VMs which cannot be migrated in live mode.
+      shutDownVMs: Check <b>Force</b> option to shutdown virtual machines which cannot be migrated in live mode.
       force: Force
     cordon:
       title: Cordon
@@ -364,7 +364,7 @@ harvester:
       mode: Mode
       modeLink: Mode <a href="https://docs.harvesterhci.io/v1.1/host/#ksmtuned-mode" target="_blank"><i class="icon icon-info" /></a>
       thresCoef: Threshold Coefficient
-      enableMergeNodes: Enable Merge Across Nodes
+      enableMergeNodes: Enable merging across nodes
       enable: Enable
       disable: Disable
       ksmStatus: KSM Status
@@ -372,7 +372,7 @@ harvester:
         standard: Standard
         high: High-Perfomanace
         customized: Customized
-      parameters: 
+      parameters:
         title: Ksmtuned Parameters
         boost: Boost
         decay: Decay
@@ -424,7 +424,7 @@ harvester:
         addLabel: Add Disk Tag
       conditions: Conditions
       storageAvailable:
-        label: Storage Available 
+        label: Storage Available
       storageScheduled:
         label: Storage Scheduled
       storageMaximum:
@@ -441,7 +441,7 @@ harvester:
       placeholder: e.g. IPv4
       ntpSyncStatus:
         isDisabled: 'The NTP is disabled. Please check the NTP service is active.'
-        isUnsynced: 'The time is not synchronized with the NTP server {current}'
+        isUnsynced: 'The time is not synchronized with the NTP server {current}.'
 
   virtualMachine:
     label: Virtual Machines
@@ -454,7 +454,7 @@ harvester:
         nameLabel: Name
         host:
           label: Hostname
-          placeholder: default to the virtual machine name.
+          placeholder: Default to the virtual machine name.
       multiple:
         label: Multiple Instance
         nameNsDescription: Name prefix for each instance
@@ -463,9 +463,9 @@ harvester:
         nameLabel: Name Prefix
         host:
           label: Host Prefix Name
-          placeholder: default to the virtual machine name.
+          placeholder: Default to the virtual machine name.
     useTemplate:
-      label: "Use VM Template:"
+      label: "Use the virtual machine template:"
       template:
         label: Template
       version:
@@ -476,7 +476,7 @@ harvester:
     promptRemove:
       title: 'Select the volume you want to delete:'
       deleteAll: Delete All
-      tips: "Warn: The snapshots of vm will be deleted with VM and the snapshots of volume will be deleted with volume."
+      tips: "Warn: The snapshots of the virtual machine will be deleted with virtual machine and the snapshots of volume will be deleted with volume."
     unplug:
       title: 'Are you sure that you want to detach volume {name} ?'
       actionLabel: Detach
@@ -512,7 +512,7 @@ harvester:
     secureBoot: Secure Boot
     volume:
       dragTip: Drag and drop volumes, or use the volume's arrows, to change the boot order.
-      volumeTip: The VM only contains a cd-rom volume. You may want to add additional disk volumes.
+      volumeTip: The virtual machine only contains a CD-ROM volume. You may want to add additional disk volumes.
       macTip: "MAC address as seen inside the guest system."
       volumeUpdate: 'Set volume { name } successfully'
       type: Type
@@ -524,7 +524,7 @@ harvester:
       dockerImage: Docker Image
       addVolume: Add Volume
       addExistingVolume: Add Existing Volume
-      addVmImage: Add VM Image
+      addVmImage: Add a Virtual Machine Image
       addContainer: Add Container
       setFirst: Set as root volume
       saveVolume: Update Volume
@@ -557,20 +557,20 @@ harvester:
         tip: "The network-data configuration allows you to customize the instance’s networking interfaces by assigning subnet configuration, virtual device creation (bonds, bridges, vlans) routes and DNS configuration. <a href='https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-v1.html' target='_blank'>Learn more</a>"
     scheduling:
       affinity:
-        anyNode: 'Run VM on any available node'
-        schedulingRules: 'Run VM on node(s) matching scheduling rules'
-        specificNode: Run VM on specific node - (Live migration is not supported)
+        anyNode: 'Run virtual machine on any available node'
+        schedulingRules: 'Run virtual machine on node(s) matching scheduling rules'
+        specificNode: Run virtual machine on specific node - (Live migration is not supported)
       networkNotSupport: Network not support schedule
     accessCredentials:
       resetPwd:
         label: Add Basic Auth
       injectSSH:
-        label: Add SSHKey
+        label: Add SSH Key
         users: Select Users
         addUser: Add User
-      tips: qemu-guest-agent must be installed to enable Access Credentials, the VM should be restarted after credentials added. Need to enter the VM to edit password or remove SSH-Key after deleting the credentials.
+      tips: qemu-guest-agent must be installed to enable the accessing of credentials. The virtual machine needs to be restarted after credentials added. You need to be in the virtual machine to edit your password or remove an SSH-Key after deleting the credentials.
       userTips: The user to be added must already exist; otherwise, the credentials will not take effect.
-      duplicatedUser: User already exist.
+      duplicatedUser: User already exists.
       invalidUser: Invalid Username.
     input:
       name: Name
@@ -602,7 +602,7 @@ harvester:
         monitor: Monitor Data
         keypairs: SSH Keys
         cloudConfig: Cloud Config
-        metrics: VM Metrics
+        metrics: Virtual Machine Metrics
       details:
         title:
           vmDetails: Virtual Machine Details
@@ -631,7 +631,7 @@ harvester:
         flavor: Flavor
         tolerations: Tolerations
         dedicatedResources: Dedicated Resources
-        down: VM not running
+        down: Virtual machine not running
         affinityRules: Affinity Rules
         sourceNode: Source Node
         targetNode: Target Node
@@ -644,7 +644,7 @@ harvester:
         from: Generated from
         down: No events in the past hour
       console:
-        down: This Virtual Machine is down. Please start it to access its console.
+        down: This virtual machine is down. Please start it to access its console.
         shortcutKeys: Shortcut Keys
         customShortcutKeys: Custom Shortcut Keys
         management: Management Shortcut Keys
@@ -652,13 +652,13 @@ harvester:
           start: Record
           recording: Recording
           stop: Stop Recording
-          tips: Pressing the record button will capture your keyboard inputs.
+          tips: Press the record button to capture your keyboard inputs.
           send: Send
           preferredKeys: Preferred Custom Shortcut Keys
     terminationGracePeriodSeconds:
       label: Termination Grace Period
     affinity:
-      thisPodNamespace: This VM's namespace
+      thisPodNamespace: This virtual machine's namespace
       matchExpressions:
         inNamespaces: "Workloads in these namespaces"
       namespaces:
@@ -676,7 +676,7 @@ harvester:
     kind: Kind
     sourceOptions:
       new: New
-      vmImage: VM Image
+      vmImage: Virtual Machine Image
     image: Image
     frontend: Frontend
     blockdev: Block Device
@@ -688,7 +688,7 @@ harvester:
     lastBackupAt: Last Backup At
     replicasNumber: Replicas Number
     promptRemove:
-      tips: "Warn: The snapshots of volume will be deleted with volume."
+      tips: "Warn: The volume's snapshots will be deleted with this volume."
     externalLink:
       tips: Check volume details
     rebuildingMessage: 'Rebuilding: {percentage}%'
@@ -700,7 +700,7 @@ harvester:
     url: URL
     size: Size
     virtualSize: Virtual Size
-    urlTip: 'supports the <code>raw</code> and <code>qcow2</code> image formats which are supported by <a href="https://www.qemu.org/docs/master/system/images.html#disk-image-file-formats" target="_blank">qemu</a>. Bootable ISO images can also be used and are treated like <code>raw</code> images.'
+    urlTip: 'Supports the <code>raw</code> and <code>qcow2</code> image formats which are supported by <a href="https://www.qemu.org/docs/master/system/images.html#disk-image-file-formats" target="_blank">qemu</a>. Bootable ISO images can also be used and are treated like <code>raw</code> images.'
     fileName: File Name
     uploadFile: Upload File
     source: Source
@@ -725,10 +725,10 @@ harvester:
     tips:
       notExistImage:
         title: Image {name} does not exist!
-        message: Please select a new Image.
+        message: Please select a new image.
       notExistNode:
         title: Node {name} does not exist!
-        message: Please select a new Node.
+        message: Please select a new node.
 
   upgradePage:
     upgradeApp: Upgrade Software
@@ -745,8 +745,8 @@ harvester:
     selectExisting: Select Existing Image
     createRepository: Creating Upgrade Repository
     succeeded: Succeeded
-    releaseTip: Please read the upgrade documentation carefully. You can view details on the <a href="{url}" target="_blank">Harvester Release Note</a>.
-    checkReady: I have read and understood the upgrade content related to this Harvester version.
+    releaseTip: Please read the upgrade documentation carefully. You can view details on the <a href="{url}" target="_blank">Harvester Release Notes</a>.
+    checkReady: I have read and understood the upgrade instructions related to this Harvester version.
     pending: Pending
     repoInfo:
       upgradeStatus: Upgrade Status
@@ -756,7 +756,7 @@ harvester:
       harvesterChart: Harvester Chart
       success: Success
       fail:  Fail
-      ongoing: on-going
+      ongoing: On-going
       downloadLog: Download Log
       logStatus: Log Download Status
     dismissMessage: Dismiss it
@@ -764,10 +764,10 @@ harvester:
       warning: WARNING
       doc: Before you upgrade to the newer Harvester version, you must perform the required <a href="https://docs.harvesterhci.io/v1.0/upgrade/automatic/" target="_blank"> pre-upgrade checks </a>for your cluster. Complete only those tasks that apply to your environment.
       tip: Failure to perform these checks may result in a failed upgrade or hitting known issues that require a manual workaround fix.
-      moreNotes: For more details about the release notes, please visit - 
+      moreNotes: For more details about the release notes, please visit -
 
   backup:
-    label: VM Backups
+    label: Virtual Machine Backups
     createText: Restore Backup
     title: Restore Virtual Machine
     backupTargetTip: The endpoint used to access the backupstore. NFS and S3 are supported.
@@ -777,8 +777,8 @@ harvester:
         middle: 'setting'
         suffix: before creating a new backup.
       errorTip:
-        prefix: Backup Target value in
-        middle: Setting
+        prefix: Backup target value in
+        middle: setting
         suffix: "is invalid, error: "
       viewSetting:
         prefix: Click
@@ -797,7 +797,7 @@ harvester:
       virtualMachineName: Virtual Machine Name
       keepMacAddress: Keep MAC Address
     matchTarget: The current backup target does not match the existing one.
-    progress: 
+    progress:
       details: Volume details
       tooltip:
         starting: Backup initiating
@@ -813,21 +813,21 @@ harvester:
         complete: Restore completed
 
   network:
-    label: VM Networks
+    label: Virtual Machine Networks
     tabs:
       basics: Basics
       layer3Network: Route
     clusterNetwork:
       label: Cluster Network
-      create: Create a New Cluster Network
+      create: Create a new cluster network
       toolTip: Define your custom cluster scope network name
-      createPlaceholder: Input a new Cluster Network name
-      selectOrCreatePlaceholder: Select or Create a new Cluster Network
-      selectPlaceholder: Select a Cluster Network
+      createPlaceholder: Input a new cluster network name
+      selectOrCreatePlaceholder: Select or create a new cluster network
+      selectPlaceholder: Select a cluster network
     layer3Network:
       mode:
         label: Mode
-        auto: Auto(DHCP)
+        auto: Auto (DHCP)
         manual: Manual
       serverIPAddr:
         label: DHCP Server IP
@@ -851,9 +851,9 @@ harvester:
     validation:
       physicalNIC: DefaultPhysicalNIC
     placeholder:
-      accessKeyId: specify your access key id
-      secretAccessKey: specify your secret access key
-      cert: upload a self-signed SSL certificate
+      accessKeyId: Specify your access key ID
+      secretAccessKey: Specify your secret access key
+      cert: Upload a self-signed SSL certificate
     vlanChangeTip: The newly modified default network interface only applies to newly added nodes, not existing ones.
     defaultPhysicalNIC: Default Network Interface
     percentTip: The value in parentheses represents the distribution percentage of the network interface on all hosts. If an interface less than 100% is selected, the user needs to manually specify the network interface on the host where the vlan network configuration fails.
@@ -878,8 +878,8 @@ harvester:
         placeholder: e.g. 172.16.0.1/32
         invalid: '"Exclude list" is invalid.'
         addIp: Add Exclude IP
-      warning: 'WARNING: <br/> Any change to storage-network requires shutting down all VMs before applying this setting. <br/> Users have to ensure the Cluster Network is configured and VLAN Config will cover all nodes and ensure the network connectivity is working and expected in all nodes.'
-      tip: 'IP Range should be in IPV4 format. <code>Number of IPs Required = Number of Nodes * 4 + Number of Disks * 2 + Number of Images to Download/Upload </code>. See <a href="https://docs.harvesterhci.io/v1.2/advanced/storagenetwork#configuration-example" target="_blank">doc</a> for more details.'
+      warning: 'WARNING: <br/> Any change to storage-network requires shutting down all virtual machines before applying this setting. <br/> Users have to ensure the cluster network is configured and VLAN Configuration will cover all nodes and ensure the network connectivity is working and expected in all nodes.'
+      tip: 'IP Range should be in IPv4 format. <code>Number of IPs Required = Number of Nodes * 4 + Number of Disks * 2 + Number of Images to Download/Upload </code>. See <a href="https://docs.harvesterhci.io/v1.2/advanced/storagenetwork#configuration-example" target="_blank">doc</a> for more details.'
     vmForceDeletionPolicy:
       period: Period
     autoRotateRKE2Certs:
@@ -932,16 +932,16 @@ harvester:
         retention: How long to retain metrics
         retentionSize: Maximum size of metrics
     clusterRegistrationUrl:
-      message: To completely unset the imported Harvester cluster, please also remove it on the Rancher dashboard UI via the <code> Virtualization Management </code> page.
+      message: To completely unset the imported Harvester cluster, please also remove it on the Rancher Dashboard UI via the <code> Virtualization Management </code> page.
     ntpServers:
       isNotIPV4: The address you entered is not IPv4 or host. Please enter a valid IPv4 address or a host address.
       isDuplicate: There are duplicate NTP server configurations.
   cloudTemplate:
-    label: Cloud Config Templates
+    label: Cloud Configuration Templates
     templateType: Template Type
     userData: User Data
     networkData: Network Data
- 
+
   support:
     title: Harvester Support
     kubeconfig:
@@ -950,7 +950,7 @@ harvester:
     internal:
       rancher:
         title: Access Embedded Rancher UI
-        titleDescription: We only support to use the embedded Rancher dashboard for debugging and validation purpose. For Rancher's multi-cluster and multi-tenant integration, please refer to the docs <a target="_blank" href="https://docs.harvesterhci.io/v1.2/rancher/index" rel="noopener noreferrer nofollow">here</a>.
+        titleDescription: We only support to use the embedded Rancher dashboard for debugging and validation purpose. For Rancher's multi-cluster and multi-tenant integration, please refer to the documentation <a target="_blank" href="https://docs.harvesterhci.io/v1.2/rancher/index" rel="noopener noreferrer nofollow">here</a>.
       longhorn:
         title: Access Embedded Longhorn UI
         titleDescription: We only support to use the embedded Longhorn UI for debugging and validation purpose.
@@ -970,7 +970,7 @@ harvester:
     cidr:
       label: CIDR/IP Range
       invalid: '"CIDR/IP Range" is invalid.'
-      toolTip: "We can apply multiple pools or ranges by seperating them with commas. i.e. 192.168.0.200/30,192.168.0.200/29 or 192.168.0.10-192.168.0.11"
+      toolTip: "We can apply multiple pools or ranges by seperating them with commas. For example: 192.168.0.200/30,192.168.0.200/29 or 192.168.0.10-192.168.0.11"
     add:
       label: Add IP Pools
 
@@ -979,22 +979,22 @@ harvester:
       label: Protocols
     ciphers:
       label: Ciphers
-  
+
   monitoring:
     configuration:
       label: Configuration
     alertmanagerConfig:
       label: Alertmanager Configs
       diabledMonitoringTips:
-        prefix: 'You must enable'
-        middle: 'Monitoring'
-        suffix: 'addon at first.'
+        prefix: 'Enable the'
+        middle: 'monitoring'
+        suffix: 'add-on first.'
       diabledAlertingTips:
-        prefix: 'You must enable'
+        prefix: 'Enable'
         middle: 'Alertmanager'
-        suffix: 'for configs to take effect.'
+        suffix: 'for configuration to take effect.'
       disabledAddon:
-        prefix: 'Monitoring Addon is disabled now, click'
+        prefix: 'The monitoring add-on is disabled, click'
         middle: 'here'
         suffix: 'to enable it.'
 
@@ -1012,9 +1012,9 @@ harvester:
     output:
       label: Output
     diabledTips:
-        prefix: 'You must enable'
-        middle: 'Logging'
-        suffix: 'for configs to take effect.'
+        prefix: 'Enable'
+        middle: 'logging'
+        suffix: 'for configuration to take effect.'
 
   snapshot:
     label: Volume Snapshots
@@ -1023,7 +1023,7 @@ harvester:
     image: Image
 
   vmSnapshot:
-    label: VM Snapshots
+    label: Virtual Machine Snapshots
     createText: Restore Snapshot
     snapshot: Snapshot
 
@@ -1045,7 +1045,7 @@ harvester:
     title: Storage Classes
     customize:
       volumeBindingMode:
-        later: Bind and provision a persistent volume once a VM using the PersistentVolumeClaim is created
+        later: Bind and provision a persistent volume once a virtual machine using the PersistentVolumeClaim is created
     parameters:
       numberOfReplicas:
         label: Number Of Replicas
@@ -1061,11 +1061,11 @@ harvester:
         label: Migratable
     allowedTopologies:
       title: Allowed Topologies
-      tooltip: Allowed Topologies helps scheduling VMs on hosts which match all of below expressions.
+      tooltip: Allowed Topologies helps scheduling virtual machines on hosts which match all of below expressions.
 
   vlanConfig:
-    title: Network Configs
-    createNetworkConfig: Create Network Config
+    title: Network Configuration
+    createNetworkConfig: Create Network Configuration
     action:
       migrate: Migrate
     titles:
@@ -1087,7 +1087,7 @@ harvester:
         validate:
           available: NIC "{nic}" is not available on the selected nodes
       linkAttributes:
-        mtu: 
+        mtu:
           label: MTU
       bondOptions:
         mode:
@@ -1106,39 +1106,39 @@ harvester:
 
   vlanStatus:
     vlanConfig:
-      label: Network Config
-  
+      label: Network Configuration
+
   clusterNetwork:
-    title: Cluster Networks/Configs
+    title: Cluster Network Configuration
     create:
       button:
-        label: Create Cluster Network
-    clusterNetwork: There are no network configs defined.
+        label: Create a Cluster Network
+    clusterNetwork: There are no network configurations defined.
     mgmt: mgmt is a built-in cluster management network and does not support any additional network configurations.
     notExist: 'Cluster Network "{ clusterNetwork }" does not exist'
     notReady: 'Cluster Network "{ clusterNetwork }" is not ready'
-  
+
   addons:
     descriptions:
-      'harvester-system/vm-import-controller': vm-import-controller is an addon to help migrate VM workloads from other source clusters to an existing Harvester cluster.
-      'harvester-system/pcidevices-controller': pcidevices-controller is an addon to help discover PCI devices for nodes in your cluster and allow users to prepare devices for PCI Passthrough, for use with Harvester VM and guest Clusters.
-      'cattle-logging-system/rancher-logging': rancher-logging is an addon to collect versatile logs, events and audits from the Harvester cluster and route them to many kinds of servers based on flows.
-      'harvester-system/rancher-vcluster': rancher-vcluster deploys a vcluster with rancher installed.
-      'cattle-monitoring-system/rancher-monitoring': rancher-monitoring is an addon to collect Harvester cluster and VM metrics, view them on the embedded dashboard, and send alert(s) to remote servers.
-      'vm-import-controller': vm-import-controller is an addon to help migrate VM workloads from other source clusters to an existing Harvester cluster.
-      'pcidevices-controller': pcidevices-controller is an addon to help discover PCI devices for nodes in your cluster and allow users to prepare devices for PCI Passthrough, for use with Harvester VM and guest Clusters.
-      'nvidia-driver-toolkit': 'nvidia-driver-toolkit is an addon to enable vGPU devices and assign them to Harvester VMs.'
-      'rancher-logging': rancher-logging is an addon to collect versatile logs, events and audits from the Harvester cluster and route them to many kinds of servers based on flows.
-      'rancher-monitoring': rancher-monitoring is an addon to collect Harvester cluster and VM metrics, view them on the embedded dashboard, and send alert(s) to remote servers.
-      'rancher-vcluster': rancher-vcluster deploys a vcluster with rancher installed.
-      'harvester-seeder': harvester-seeder is an addon that uses ipmi and redfish to discover hardware information and perform out-of-band operations.
-      'harvester-system/harvester-seeder': harvester-seeder is an addon that uses ipmi and redfish to discover hardware information and perform out-of-band operations.
+      'harvester-system/vm-import-controller': vm-import-controller is an add-on to help migrate virtual machine workloads from other source clusters to an existing Harvester cluster.
+      'harvester-system/pcidevices-controller': pcidevices-controller is an add-on to help discover PCI devices for nodes in your cluster and allow users to prepare devices for PCI Passthrough, for use with Harvester virtual machine and guest clusters.
+      'cattle-logging-system/rancher-logging': rancher-logging is an add-on to collect versatile logs, events, and audits from the Harvester cluster and route them to many kinds of servers based on flows.
+      'harvester-system/rancher-vcluster': rancher-vcluster deploys a virtual cluster (vcluster) with Rancher installed.
+      'cattle-monitoring-system/rancher-monitoring': rancher-monitoring is an add-on that collects Harvester cluster and virtual machine metrics and allows you to view the metrics on an embedded dashboard and send alert(s) to remote servers.
+      'vm-import-controller': vm-import-controller is an add-on to help migrate virtual machine workloads from other source clusters to an existing Harvester cluster.
+      'pcidevices-controller': pcidevices-controller is an add-on to help discover PCI devices for nodes in your cluster and allow users to prepare devices for PCI Passthrough, for use with Harvester virtual machines and guest clusters.
+      'nvidia-driver-toolkit': 'nvidia-driver-toolkit is an add-on to enable vGPU devices and assign them to Harvester virtual machines.'
+      'rancher-logging': rancher-logging is an add-on to collect versatile logs, events, and audits from the Harvester cluster and route them to many kinds of servers based on flows.
+      'rancher-monitoring': rancher-monitoring is an add-on to collect Harvester cluster and virtual machine metrics, view them on the embedded dashboard, and send alert(s) to remote servers.
+      'rancher-vcluster': rancher-vcluster deploys a virtual cluster (vcluster) with Rancher installed.
+      'harvester-seeder': harvester-seeder is an add-on that uses IPMI and Redfish to discover hardware information and perform out-of-band operations.
+      'harvester-system/harvester-seeder': harvester-seeder is an add-on that uses IPMI and Redfish to discover hardware information and perform out-of-band operations.
     vmImport:
       titles:
         basic: Basic
         pvc: Volume
     rancherVcluster:
-      accessRancher: Access Rancher Dashboard
+      accessRancher: Access the Rancher Dashboard
       hostname: Hostname
       rancherVersion: Rancher Version
       password: Bootstrap Password
@@ -1199,12 +1199,12 @@ harvester:
       label: Backend Servers
     healthCheck:
       warning:
-        portInUse: Warning, Backend Port {port} is in use in Health Check settings; in case of updating the port, update the Health Check settings accordingly.
+        portInUse: Warning, the Backend Port {port} is in use in Health Check settings. If you need to update the port, update the Health Check settings accordingly.
 
   ipPool:
     label: IP Pools
     network:
-      label: VM Network
+      label: Virtual Machine Network
     tabs:
       range: Range
       scope: Scope
@@ -1234,13 +1234,13 @@ harvester:
       addLabel: Add CIDR
     range:
       addLabel: Add Range
-      
+
   service:
     healthCheckPort:
       label: Health Check Port
     healthCheckSuccessThreshold:
       label: Health Check Success Threshold
-      description: If the number of times the prober continuously detects an address successfully reaches the success threshold, then the backend server can start to forward traffic.
+      description: If the number of times the probe continuously detects an address successfully reaches the success threshold, then the backend server can start to forward traffic.
     healthCheckFailureThreshold:
       label: Health Check Failure Threshold
       description: The backend server will stop forwarding traffic if the number of health check failures reaches the failure threshold.
@@ -1265,22 +1265,22 @@ harvester:
   sriovgpu:
     label: SR-IOV GPU Devices
     nodeName: Node
-    numVFs: Number Of Virtual Functions
+    numVFs: Number of Virtual Functions
     vfAddresses: Virtual Functions Addresses
     vGpuDevices: vGPU Devices
     showMore: Show More
     parentSriov: Filter By Parent SR-IOV GPU
-    noPermission: Please contact system admin to add Harvester addons first
+    noPermission: Please contac your system admiistrator to add Harvester add-ons first.
     goSetting:
-      prefix: The nvidia-driver-toolkit addon is not enabled, click
+      prefix: The nvidia-driver-toolkit add-on is not enabled, click
       middle: here
       suffix: to enable it to manage your SR-IOV GPU devices.
 
   vgpu:
     label: vGPU Devices
-    noPermission: Please contact system admin to add Harvester addons first
+    noPermission: Please contact system administrator to add Harvester add-ons first.
     goSetting:
-      prefix: The nvidia-driver-toolkit addon is not enabled, click
+      prefix: The nvidia-driver-toolkit add-on is not enabled, click
       middle: here
       suffix: to enable it to manage your vGPU devices.
     enableGroup: Enable Group
@@ -1291,22 +1291,22 @@ harvester:
     available: Available Devices
     compatibleNodes: Compatible Nodes
     impossibleSelection: 'There are no hosts with all of the selected devices.'
-    howToUseDevice: 'Use the table below to enable vGPU devices you want to use in this VM.'
+    howToUseDevice: 'Use the table below to enable vGPU devices you want to use in this virtual machine.'
     deviceInTheSameHost: 'You can only select devices on the same host.'
 
   harvesterVlanConfigMigrateDialog:
-    targetClusterNetwork: 
+    targetClusterNetwork:
       label: Target Cluster Network
       placeholder: Choose Target Cluster Network
 
   seeder:
     banner:
       enable:
-        prefix: Addon "harvester-seeder" is disabled now, 
-        middle: click here 
+        prefix: The "harvester-seeder" add-on is disabled.
+        middle: Click here
         suffix: to enable it.
-      noAccess: Please contact system admin to enable the Out-of-Band Access first.
-      noAddon: Addon "harvester-seeder" is not exist, please check if it is installed.
+      noAccess: Please contact your system administrator to enable the Out-of-Band Access first.
+      noAddon: The "harvester-seeder" add-on does not exist, please check if it is installed.
       noInventory: Waiting for "inventories.metal.harvesterhci.io" to be ready.
     inventory:
       host:
@@ -1327,10 +1327,10 @@ harvester:
         label: Polling Interval
 
   affinity:
-    thisPodNamespace: This VM's namespace
+    thisPodNamespace: This virtual machine's namespace
     matchExpressions:
       inNamespaces: "Workloads in these namespaces"
-    vmAffinityTitle: VM Scheduling
+    vmAffinityTitle: Virtual Machine Scheduling
     namespaces:
       placeholder: e.g. default,system,base
       label: Namespaces
@@ -1341,35 +1341,35 @@ harvester:
 advancedSettings:
   descriptions:
     'harv-vlan': Default Network Interface name of the VLAN network.
-    'harv-backup-target': Custom backup target to store VM backups.
-    'branding': Branding allows administrators to globally re-brand the UI by customizing the Harvester product name, logos and color scheme.
-    'harv-csi-driver-config': Configure additional information for csi drivers.
+    'harv-backup-target': Custom backup target to store virtual machine backups.
+    'branding': Branding allows administrators to globally re-brand the UI by customizing the Harvester product name, logos, and color scheme.
+    'harv-csi-driver-config': Configure additional information for CSI drivers.
     'harv-containerd-registry': Containerd Registry Configuration to connect private registries.
-    'harv-log-level': Configure Harvester server log level. Default to info.
+    'harv-log-level': Configure Harvester server log level. Defaults to Info.
     'harv-server-version': Harvester server version.
-    'harv-upgrade-checker-enabled': Specify whether to enable Harvester upgrade check or not. Default is true.
-    'harv-upgrade-checker-url': Default Harvester upgrade check url. Only used when the <code>upgrade-checker-enabled</code>  is equal to true.
-    'harv-ui-source': Config how to load the UI source.
+    'harv-upgrade-checker-enabled': Specifies whether to enable Harvester upgrade check or not. Default is True.
+    'harv-upgrade-checker-url': Default Harvester upgrade check url. Only used when the <code>upgrade-checker-enabled</code> is equal to True.
+    'harv-ui-source': Configuration for how to load the UI source.
     'harv-ui-index': 'HTML index location for the UI.'
-    'harv-ui-plugin-index': 'JS index location for the harvester plugin UI.'
-    'harv-cluster-registration-url': Registration URL for mutil-cluster management.
+    'harv-ui-plugin-index': 'JS index location for the Harvester plugin UI.'
+    'harv-cluster-registration-url': Registration URL for multi-cluster management.
     'harv-http-proxy': 'HTTP proxy for Harvester to access external services.'
     'harv-additional-ca': 'Custom CA root certificates for TLS validation.'
     'harv-overcommit-config': 'Resource overcommit configuration.'
-    'harv-support-bundle-timeout': 'Support Bundle timeout config in minutes, use 0 to disable the timeout.'
-    'harv-support-bundle-expiration': 'Support Bundle expiration config in minutes.'
-    'harv-support-bundle-node-collection-timeout': 'Support Bundle node collection timeout config in minutes.'
-    'harv-vm-force-reset-policy': Config the force-reset action when a VM is stuck on a node that is down.
+    'harv-support-bundle-timeout': 'Support bundle timeout configuration in minutes, use 0 to disable the timeout.'
+    'harv-support-bundle-expiration': 'Support bundle expiration configuration in minutes.'
+    'harv-support-bundle-node-collection-timeout': 'Support bundle node collection timeout configuration in minutes.'
+    'harv-vm-force-reset-policy': Configuration for the force-reset action when a virtual machine is stuck on a node that is down.
     'harv-ssl-parameters': Custom SSL Parameters for TLS validation.
     'harv-storage-network': 'Longhorn storage-network setting.'
     'harv-support-bundle-namespaces': Specify resources in other namespaces to be collected by the support package.
-    'harv-auto-disk-provision-paths': Specify the disks(using glob pattern) that Harvester will automatically add as VM storage.
+    'harv-auto-disk-provision-paths': Specify the disks(using glob pattern) that Harvester will automatically add as virtual machine storage.
     'harv-support-bundle-image': Support bundle image configuration. Find different versions in <a href="https://hub.docker.com/r/rancher/support-bundle-kit/tags" target="_blank">rancher/support-bundle-kit</a>.
     'harv-release-download-url': This setting allows you to configure the <code>upgrade release download</code> URL address. Harvester will get the ISO URL and checksum value from the (<code>$URL</code>/<code>$VERSION</code>/version.yaml) file hosted by the configured URL.
-    'harv-default-vm-termination-grace-period-seconds': Config the VM termination grace period for VM stop.
+    'harv-default-vm-termination-grace-period-seconds': Configure the virtual machine termination grace period for virtual machine stop.
     'harv-ntp-servers': Configure NTP server. You can configure multiple IPv4 addresses or host addresses.
     'harv-auto-rotate-rke2-certs': The certificate rotation mechanism relies on Rancher. Harvester will automatically update certificates generation to trigger rotation.
-    'harv-kubeconfig-default-token-ttl-minutes': 'TTL (in minutes) applied on Harvester admin kubeconfig files. Default is 0, which means to never expire.'
+    'harv-kubeconfig-default-token-ttl-minutes': 'TTL (in minutes) applied on Harvester administration kubeconfig files. Default is 0, which means to never expire.'
 
 typeLabel:
   kubevirt.io.virtualmachine: |-
@@ -1394,8 +1394,8 @@ typeLabel:
     }
   harvesterhci.io.networkattachmentdefinition: |-
     {count, plural,
-      one { VM Network }
-      other { VM Networks }
+      one { Virtual Machines Network }
+      other { Virtual Machines Networks }
     }
   harvesterhci.io.volume: |-
     {count, plural,
@@ -1419,13 +1419,13 @@ typeLabel:
     }
   harvesterhci.io.virtualmachinebackup: |-
     {count, plural,
-      one { VM Backup }
-      other { VM Backups }
+      one { Virtual Machines Backup }
+      other { Virtual Machines Backups }
     }
   harvesterhci.io.cloudtemplate: |-
     {count, plural,
-      one { Cloud Config Template }
-      other { Cloud Config Templates }
+      one { Cloud Configuration Template }
+      other { Cloud Configuration Templates }
     }
   harvesterhci.io.volumesnapshot: |-
     {count, plural,
@@ -1434,18 +1434,18 @@ typeLabel:
     }
   harvesterhci.io.vmsnapshot: |-
     {count, plural,
-      one { VM Snapshot }
-      other { VM Snapshots }
+      one { Virtual Machines Snapshot }
+      other { Virtual Machines Snapshots }
     }
   network.harvesterhci.io.vlanconfig: |-
     {count, plural,
-      one { Network Config }
-      other { Network Configs }
+      one { Network Configuration }
+      other { Network Configurations }
     }
   harvesterhci.io.monitoring.alertmanagerconfig: |-
     {count, plural,
-      one { Alertmanager Config }
-      other { Alertmanager Configs }
+      one { Alertmanager Configuration }
+      other { Alertmanager Configurations }
     }
   harvesterhci.io.logging.clusterflow: |-
     {count, plural,

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -762,8 +762,8 @@ harvester:
     dismissMessage: Dismiss it
     upgradeInfo:
       warning: WARNING
-      doc: Before you upgrade to the newer Harvester version, you must perform the required <a href="https://docs.harvesterhci.io/v1.0/upgrade/automatic/" target="_blank"> pre-upgrade checks </a>for your cluster. Complete only those tasks that apply to your environment.
-      tip: Failure to perform these checks may result in a failed upgrade or hitting known issues that require a manual workaround fix.
+      doc: Read the <a href="https://docs.harvesterhci.io/v1.4/upgrade/index" target="_blank">documentation</a> before starting the upgrade process. Ensure that you complete procedures that are relevant to your environment and the version you are upgrading to.
+      tip: Unmet system requirements and incorrectly performed procedures may cause complete upgrade failure and other issues that require manual workarounds.
       moreNotes: For more details about the release notes, please visit -
 
   backup:
@@ -879,7 +879,7 @@ harvester:
         invalid: '"Exclude list" is invalid.'
         addIp: Add Exclude IP
       warning: 'WARNING: <br/> Any change to storage-network requires shutting down all virtual machines before applying this setting. <br/> Users have to ensure the cluster network is configured and VLAN Configuration will cover all nodes and ensure the network connectivity is working and expected in all nodes.'
-      tip: 'IP Range should be in IPv4 format. <code>Number of IPs Required = Number of Nodes * 4 + Number of Disks * 2 + Number of Images to Download/Upload </code>. See <a href="https://docs.harvesterhci.io/v1.2/advanced/storagenetwork#configuration-example" target="_blank">doc</a> for more details.'
+      tip: 'Specify an IP range in the IPv4 CIDR format. <code>Number of IPs Required = Number of Nodes * 4 + Number of Disks * 2 + Number of Images to Download/Upload </code>. For more information about storage network settings, see the <a href="https://docs.harvesterhci.io/v1.4/advanced/storagenetwork#configuration-example" target="_blank">documentation</a>.'
     vmForceDeletionPolicy:
       period: Period
     autoRotateRKE2Certs:
@@ -950,7 +950,7 @@ harvester:
     internal:
       rancher:
         title: Access Embedded Rancher UI
-        titleDescription: We only support to use the embedded Rancher dashboard for debugging and validation purpose. For Rancher's multi-cluster and multi-tenant integration, please refer to the documentation <a target="_blank" href="https://docs.harvesterhci.io/v1.2/rancher/index" rel="noopener noreferrer nofollow">here</a>.
+        titleDescription: You can only use the embedded Rancher UI for debugging and validation purposes. For more information about how Harvester integrates with Rancher, see the <a target="_blank" href="https://docs.harvesterhci.io/v1.4/rancher/rancher-integration" rel="noopener noreferrer nofollow">documentation</a>.
       longhorn:
         title: Access Embedded Longhorn UI
         titleDescription: We only support to use the embedded Longhorn UI for debugging and validation purpose.
@@ -1370,6 +1370,7 @@ advancedSettings:
     'harv-ntp-servers': Configure NTP server. You can configure multiple IPv4 addresses or host addresses.
     'harv-auto-rotate-rke2-certs': The certificate rotation mechanism relies on Rancher. Harvester will automatically update certificates generation to trigger rotation.
     'harv-kubeconfig-default-token-ttl-minutes': 'TTL (in minutes) applied on Harvester administration kubeconfig files. Default is 0, which means to never expire.'
+    'harv-longhorn-v2-data-engine-enabled': 'Enable the Longhorn V2 data engine. Default is false. <ul><li>Changing this setting will restart RKE2 on all nodes. This will not affect running VM workloads.</li><li>If you see "not enough hugepages-2Mi capacity" errors when enabling this setting, wait a minute for the error to clear. If the error remains, reboot the affected node.</li></ul>'
 
 typeLabel:
   kubevirt.io.virtualmachine: |-

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -773,7 +773,7 @@ harvester:
     backupTargetTip: The endpoint used to access the backupstore. NFS and S3 are supported.
     message:
       noSetting:
-        prefix: You must configure the backup target in
+        prefix: You must configure the backup target
         middle: 'setting'
         suffix: before creating a new backup.
       errorTip:
@@ -1270,7 +1270,7 @@ harvester:
     vGpuDevices: vGPU Devices
     showMore: Show More
     parentSriov: Filter By Parent SR-IOV GPU
-    noPermission: Please contac your system admiistrator to add Harvester add-ons first.
+    noPermission: Please contact your system admiistrator to add Harvester add-ons first.
     goSetting:
       prefix: The nvidia-driver-toolkit add-on is not enabled, click
       middle: here

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1635,21 +1635,21 @@ cluster:
       custom: Use custom affinity rules
   advanced:
     argInfo:
-      title: Additional Kubelet Args
+      title: Additional Kubelet Arguments
       machineSelector:
         label: Add Machine Selector
-        listLabel: Add Args
-        bannerLabel: 'Note: The last selector that matches wins and only args from it will be used. Args from other matches above will not combined together or merged.'
+        listLabel: Add Arguments
+        bannerLabel: 'Note: The last selector that matches wins and only arguments from it will be used. Arguments from other matches above will not combined together or merged.'
         title: 'For machines with labels matching:'
-        subTitle: 'Use the Kubelet args:'
+        subTitle: 'Use the Kubelet arguments:'
         titleAlt:  |-
           {count, plural,
-            =1 { For all machines, use the Kubelet args: }
-            other { For any machines, use the Kubelet args: }
+            =1 { For all machines, use the Kubelet arguments: }
+            other { For any machines, use the Kubelet arguments: }
           }
-        kubeControllerManagerTitle: Additional Controller Manager Args
-        kubeApiServerTitle: Additional API Server Args
-        kubeSchedulerTitle: Additional Scheduler Args
+        kubeControllerManagerTitle: Additional Controller Manager Arguments
+        kubeApiServerTitle: Additional API Server Arguments
+        kubeSchedulerTitle: Additional Scheduler Arguments
     agentArgs:
       label: Raise error if kernel parameters are different than the expected kubelet defaults
   banner:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3592,8 +3592,8 @@ node:
         used: Used
         amount: "{used} of {total} {unit}"
         cpu: CPU
-        memory: MEMORY
-        pods: PODS
+        memory: Memory
+        pods: Pods
       diskPressure: Disk Pressure
       kubelet: kubelet
       memoryPressure: Memory Pressure
@@ -3806,7 +3806,7 @@ persistentVolume:
     portals:
       add: Add Portal
   cinder:
-    label: Openstack Cinder Volume (Unsupported)
+    label: OpenStack Cinder Volume (Unsupported)
     volumeId:
       label: Volume ID
       placeholder: e.g. vol
@@ -3891,7 +3891,7 @@ persistentVolume:
       label: Path on the Node
       placeholder: /mnt/disks/ssd1
     mustBe:
-      label: The Path on the Node must be
+      label: The path on the node must be
       anything: 'Anything: do not check the target path'
       directory: A directory, or create if it does not exist
       file: A file, or create if it does not exist
@@ -3954,8 +3954,8 @@ persistentVolumeClaim:
   source:
     label: Source
     options:
-      new: Use a Storage Class to provision a new Persistent Volume
-      existing: Use an existing Persistent Volume
+      new: Use a storage class to provision a new persistent volume
+      existing: Use an existing persistent volume
   expand:
     label: Expand
     notSupported: Storage class does not support volume expansion
@@ -3966,8 +3966,8 @@ persistentVolumeClaim:
     requestStorage: Request Storage
     persistentVolume: Persistent Volume
     tooltips:
-      noStorageClass: You don't have permission to list Storage Classes, enter a name manually
-      noPersistentVolume: You don't have permission to list Persistent Volumes, enter a name manually
+      noStorageClass: You do not have permission to list storage classes, enter a name manually
+      noPersistentVolume: You do not have permission to list persistent volumes, enter a name manually
   customize:
     label: Customize
     accessModes:
@@ -4006,18 +4006,18 @@ plugins:
     installing: Installing ...
     uninstalling: Uninstalling ...
   descriptions:
-    experimental: This Extension is marked as experimental
-    third-party: This Extension is provided by a Third-Party
-    built-in: This Extension is built-in
-    image: This Extension Image has been loaded manually
+    experimental: This extension is marked as experimental
+    third-party: This extension is provided by a third-party
+    built-in: This extension is built-in
+    image: This extension image has been loaded manually
   error:
     title: Error loading extension
     message: Could not load extension code
     generic: Extension error
-    api: This Extension is not compatible with the Extensions API
-    host: This Extension is not compatible with this application
-    version: This Extension is not compatible with this version of Rancher
-    load: An error occurred loading the code for this Extension
+    api: This extension is not compatible with the extension API
+    host: This extension is not compatible with this application
+    version: This extension is not compatible with this version of Rancher
+    load: An error occurred loading the code for this extension
   success:
     title: Loaded extension {name}
     message: Extension was loaded successfully
@@ -4036,10 +4036,10 @@ plugins:
     requiresVersion: "Requires Rancher {version}"
   empty:
     all: Extensions are neither installed nor available
-    available: No Extensions available
-    installed: No Extensions installed
-    updates: No updates available for installed Extensions
-    images: No Extension Images installed
+    available: No extension available
+    installed: No extension installed
+    updates: No updates available for installed extension
+    images: No extension images installed
   loadError: An error occurred loading the code for this extension
   helmError: "An error occurred installing the extension via Helm"
   manageRepos: Manage Repositories
@@ -4050,14 +4050,14 @@ plugins:
     subtitle: Catalogs
     imageLoad:
       load: Import Extension Catalog
-      prompt: An Extension Catalog contains extension assets bundled into an image, importing will take the image and host a Helm repository to act as a catalog for custom built Extensions.
+      prompt: An extension catalog contains extension assets bundled into an image, importing will take the image and host a Helm repository to act as a catalog for custom built extensions.
       fields:
         image:
           label: Catalog Image Reference
           placeholder: "e.g. hub.docker.io/example-org/my-image:latest"
         secrets:
-          banner: "If the registry that hosts the Catalog Image requires Pull Secrets, they must be created in the following namespace:<pre>cattle-ui-plugin-system</pre>"
-      banner: This will create an Deployment, Service, and Helm repository to serve the extension charts.
+          banner: "If the registry that hosts the catalog image requires pull secrets, they must be created in the following namespace:<pre>cattle-ui-plugin-system</pre>"
+      banner: This will create a deployment, service, and Helm repository to serve the extension charts.
       imageVersion:
         title: Image Version Not Found
         message: Unable to determine image version from {image}, defaulting to latest
@@ -4074,7 +4074,7 @@ plugins:
             message: A repository with the name {repo} already exists
       success:
         title: "Imported Extension Catalog from: {name}"
-        message: Extension Catalog image was imported successfully
+        message: Extension catalog image was imported successfully
     headers:
       image:
         name: images
@@ -4093,23 +4093,23 @@ plugins:
   install:
     label: Install
     title: Install Extension {name}
-    prompt: "Are you sure that you want to install this Extension?"
+    prompt: "Are you sure that you want to install this extension?"
     version: Version
-    warnNotCertified: Please ensure that you are aware of the risks of installing Extensions from untrusted authors
+    warnNotCertified: Please ensure that you are aware of the risks of installing extensions from untrusted authors
   update:
     label: Update
     title: Update Extension {name}
-    prompt: "Are you sure that you want to update this Extension?"
+    prompt: "Are you sure that you want to update this extension?"
   rollback:
     label: Rollback
     title: Rollback Extension {name}
-    prompt: "Are you sure that you want to rollback this Extension?"
+    prompt: "Are you sure that you want to rollback this extension?"
   uninstall:
     label: Uninstall
     title: "Uninstall Extension: {name}"
-    prompt: "Are you sure that you want to uninstall this Extension?"
-    custom: "Are you sure that you want to uninstall this Extension Image? This will also remove any Extensions provided by this image."
-  upgradeAvailable: A newer version of this Extension is available
+    prompt: "Are you sure that you want to uninstall this extension?"
+    custom: "Are you sure that you want to uninstall this extension image? This will also remove any extensions provided by this image."
+  upgradeAvailable: A newer version of this extension is available
   reload: Extensions changed - reload required
   safeMode:
     title: Extensions Safe Mode
@@ -4118,19 +4118,19 @@ plugins:
     title: Extension support is not enabled
     prompt:
       cant: Automatic installation is not available - required Helm Charts could not be found
-      can: You need to install the Extension Operator
+      can: You need to install the extension operator
     install:
       title: Enable Extension Support?
-      prompt: This will install the Helm charts to enable Extension support
-      airgap: The Rancher Extensions Repository provides extensions published by Rancher. Un-check if your Rancher installation is air-gapped
+      prompt: This will install the Helm charts to enable extension support
+      airgap: The Rancher extensions repository provides extensions published by Rancher. De-select if your Rancher installation is air-gapped
       addRancherRepo: Add the Rancher Extension Repository
     remove:
       label: Disable Extension Support
       title: Disable Extension Support?
-      prompt: This will un-install the Helm charts that enable Extension support
+      prompt: This will un-install the Helm charts that enable extension support
       registry:
         title: Remove the Rancher Extensions Repository
-        prompt: The Rancher Extensions Repository provides extensions published by Rancher
+        prompt: The Rancher extension repository provides extensions published by Rancher
       crd:
         title: Remove the Rancher Extensions Custom Resource Definition
         prompt: There are one or more extensions installed - removing the CRD will require you to manually reinstall these extensions if you subsequently re-enable extensions support.
@@ -4153,7 +4153,7 @@ podSecurityAdmission:
     placeholder: 'Version (default: latest)'
   exemptions:
     title: Exemptions
-    description: Allow the creation of pods for specific Usernames, RuntimeClassNames, and Namespaces that would otherwise be prohibited due to the policies set above.
+    description: Allow the creation of pods for specific usernames, RuntimeClassNames, and namespaces that would otherwise be prohibited due to the policies set above.
     placeholder: Enter a comma separated list of {psaExemptionsControl}
 prefs:
   title: Preferences
@@ -4191,9 +4191,9 @@ prefs:
   advFeatures:
     title: Advanced Features
     viewInApi: Enable "View in API"
-    allNamespaces: Show system Namespaces managed by Rancher (not intended for editing or deletion)
-    themeShortcut: Enable Dark/Light Theme keyboard shortcut toggle (shift+T)
-    pluginDeveloper: Enable Extension developer features
+    allNamespaces: Show system namespaces managed by Rancher (not intended for editing or deletion)
+    themeShortcut: Enable Dark/Light theme keyboard shortcut toggle (shift+T)
+    pluginDeveloper: Enable extension developer features
   hideDesc:
     label: Hide All Type Descriptions
   helm:
@@ -4249,9 +4249,9 @@ project:
   members:
     label: Members
   containerDefaultResourceLimit: Container Default Resource Limit
-  vmDefaultResourceLimit: VM Default Resource Limit
+  vmDefaultResourceLimit: Virtual Machine Default Resource Limit
   resourceQuotas: Resource Quotas
-  haveOneOwner: There must be at least one member with the Owner role.
+  haveOneOwner: There must be at least one member with the owner role.
   psp:
     default: Cluster Default
     label: Pod Security Policy
@@ -4263,23 +4263,23 @@ projectMembers:
     label: Project
   projectPermissions:
     label: Project Permissions
-    description: Controls what access users have to the Project
+    description: Controls what access users have to the project
     noDescription: User created - no description
     searchForMember: Search for a member to provide project access
     owner:
       label: Owner
-      description: Owners have full control over the Project and all resources inside it.
+      description: Owners have full control over the project and all resources inside it.
     member:
       label: Member
-      description: Members can manage the resources inside the Project but not change the Project itself.
+      description: Members can manage the resources inside the project but not change the project itself.
     readOnly:
       label: Read Only
-      description: Members can only view the resources inside the Project but not change the resources.
+      description: Members can only view the resources inside the project but not change the resources.
     custom:
       label: Custom
       description: Choose individual roles for this user.
     createNs: Create Namespaces
-    configmapsManage: Manage Config Maps
+    configmapsManage: Manage Configuration Maps
     ingressManage: Manage Ingress
     projectcatalogsManage: Manage Project Catalogs
     projectroletemplatebindingsManage: Manage Project Members
@@ -4324,7 +4324,7 @@ prometheusRule:
       summary:
         input: Summary Annotation Value
         label: Summary
-    bannerText: 'When firing alerts, the annotations and labels will be passed to the configured AlertManagers to allow them to construct the notification that will be sent to any configured Receivers.'
+    bannerText: 'When firing alerts, the annotations and labels will be passed to the configured AlertManagers to allow them to construct the notification that will be sent to any configured receivers.'
     for:
       label: Wait to fire for
       placeholder: '60'
@@ -4363,14 +4363,14 @@ prometheusRule:
 
 promptForceRemove:
   modalTitle: Are you sure?
-  removeWarning: "There was an issue with deleting underlying infrastructure. If you proceed with this action, the Machine <b>{nameToMatch}</b> will be deleted from Rancher only. It's highly recommended to manually delete any referenced infrastructure."
+  removeWarning: "There was an issue with deleting underlying infrastructure. If you proceed with this action, the Machine <b>{nameToMatch}</b> will be deleted from Rancher only. We recommend to manually delete any referenced infrastructure."
   forceDelete: Force Delete
   confirmName: "Enter in the pool name below to confirm:"
   podRemoveWarning: "Force deleting pods does not wait for confirmation that the pod's processes have been terminated. This may result in <strong>data corruption or inconsistencies</strong>"
 
 promptScaleMachineDown:
   attemptingToRemove: "You are attempting to delete {count} {type}"
-  retainedMachine1: At least one Machine must exist for roles Control Plane and Etcd.
+  retainedMachine1: At least one machine must exist for roles control plane and Etcd.
   retainedMachine2: <b>{ name }</b> will remain
 
 promptRemove:
@@ -4382,7 +4382,7 @@ promptRemove:
     other { and <b>{count} others</b>.}
     }
   attemptingToRemove: "You are attempting to delete the {type}"
-  attemptingToRemoveAuthConfig: "You are attempting to disable this Auth Provider. <br><br> Be aware that cluster role template bindings, project role template bindings, global role bindings, users, tokens will be all deleted. <br><br> Are you sure you want to proceed?"
+  attemptingToRemoveAuthConfig: "You are attempting to disable this authenticator provider. <br><br> Be aware that cluster role template bindings, project role template bindings, global role bindings, users, tokens will be all deleted. <br><br> Are you sure you want to proceed?"
   protip: "Tip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation"
   confirmName: "Enter <b>{nameToMatch}</b> below to confirm:"
   deleteAssociatedNamespaces: "Also delete the namespaces in this project:"
@@ -4424,7 +4424,7 @@ promptSaveAsRKETemplate:
 promptRotateEncryptionKey:
   title: Rotate Encryption Keys
   description: The last backup {name} was performed on {date}
-  warning: Before proceeding, ensure a successful ETCD backup of the cluster has been completed.
+  warning: Before proceeding, ensure a successful etcd backup of the cluster has been completed.
   error: No backup found
 
 rancherAlertingDrivers:
@@ -4524,10 +4524,10 @@ rbac:
         description: Administrators have full control over the entire installation and all resources in all clusters.
       restricted-admin:
         label: Restricted Administrator
-        description: Restricted Admins have full control over all resources in all downstream clusters but no access to the local cluster.
+        description: Restricted administrators have full control over all resources in all downstream clusters but no access to the local cluster.
       user:
         label: Standard User
-        description: Standard Users can create new clusters and manage clusters and projects they have been granted access to.
+        description: Standard users can create new clusters and manage clusters and projects they have been granted access to.
       user-base:
         label: User-Base
         description: User-Base users have login-access only.
@@ -4539,10 +4539,10 @@ rbac:
         description: Allows the user to create new RKE cluster templates and become the owner of them.
       authn-manage:
         label: Configure Authentication
-        description: Allows the user to enable, configure, and disable all Authentication provider settings.
+        description: Allows the user to enable, configure, and disable all authentication provider settings.
       catalogs-manage:
         label: Legacy Configure Catalogs
-        description: Allows the user to add, edit, and remove management.cattle.io based catalogs resources.
+        description: Allows the user to add, edit, and remove management.cattle.io-based catalog resources.
       clusters-manage:
         label: Manage all Clusters
         description: Allows the user to manage all clusters, including ones they are not a member of.
@@ -4557,31 +4557,31 @@ rbac:
         description: Allows the user to enable and disable custom features via feature flag settings.
       nodedrivers-manage:
         label: Configure Node Drivers
-        description: Allows the user to enable, configure, and remove all Node Driver settings.
+        description: Allows the user to enable, configure, and remove all node driver settings.
       nodetemplates-manage:
         label: Manage Node Templates
-        description: Allows the user to define, edit, and remove Node Templates.
+        description: Allows the user to define, edit, and remove node templates.
       podsecuritypolicytemplates-manage:
         label: Manage Pod Security Policies (PSPs)
         description: Allows the user to define, edit, and remove PSPs.
       roles-manage:
         label: Manage Roles
-        description: Allows the user to define, edit, and remove Role definitions.
+        description: Allows the user to define, edit, and remove role definitions.
       settings-manage:
         label: Manage Settings
         description: 'Allows the user to manage {vendor} Settings.'
       users-manage:
         label: Manage Users
-        description: Allows the user to create, remove, and set passwords for all Users.
+        description: Allows the user to create, remove, and set passwords for all users.
       catalogs-use:
         label: Use Catalogs
-        description: Allows the user to see and deploy Templates from the Catalog.  Standard Users have this permission by default.
+        description: Allows the user to see and deploy templates from the catalog. Standard users have this permission by default.
       nodetemplates-use:
         label: Use Node Templates
-        description: Allows the user to deploy new Nodes using any existing Node Templates.
+        description: Allows the user to deploy new nodes using any existing node templates.
       view-rancher-metrics:
         label: 'View {vendor} Metrics'
-        description: Allows the user to view Metrics through the API.
+        description: Allows the user to view metrics through the API.
       base:
         label: Login Access
       clustertemplaterevisions-create:
@@ -4622,8 +4622,8 @@ resourceDetail:
     age: Age
     restartCount: Pod Restarts
     defaultBannerMessage:
-      error: This resource is currently in an error state, but there isn't a detailed message available.
-      transitioning: This resource is currently in a transitioning state, but there isn't a detailed message available.
+      error: This resource is currently in an error state, but a detailed message is not available.
+      transitioning: This resource is currently in a transitioning state, a detailed message is not available.
     sensitive:
       hide: Hide Sensitive Values
       show: Show Sensitive Values
@@ -4637,7 +4637,7 @@ resourceDetail:
     managedWarning: |-
       This {type} is managed by {hasName, select,
         no {a {managedBy} app}
-        yes {the {managedBy} app {appName}}}; changes made here will likely be overwritten the next time {managedBy} runs.
+        yes {the {managedBy} app {appName}}}; changes made here can be overwritten the next time {managedBy} runs.
 resourceList:
   head:
     create: Create
@@ -4685,7 +4685,7 @@ resourceTabs:
 
 resourceYaml:
   errors:
-    namespaceRequired: This resource is namespaced, so a namespace must be provided.
+    namespaceRequired: This resource is namespaced; a namespace must be provided.
   buttons:
     continue: Continue Editing
     edit: Edit YAML
@@ -4756,12 +4756,12 @@ secret:
   relatedWorkloads: Related Workloads
   typeDescriptions:
     custom:
-      description: Create a Secret with a custom type
+      description: Create a secret with a custom type
     'kubernetes.io/basic-auth':
       description: 'Authentication with a username and password'
       docLink: https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret
     'Opaque':
-      description: Default type of Secret using key-value pairs
+      description: Default type of secret using key-value pairs
       docLink: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
     'kubernetes.io/dockerconfigjson':
       description: Authenticated registry for pulling container images
@@ -4830,9 +4830,9 @@ serviceTypes:
   nodeport: Node Port
 
 servicesPage:
-  serviceListDescription: Services allow you to define a logical set of Pods that can be accessed with a single IP address and port.
-  targetPorts: The Service will send requests to this port, and the selected Pods are expected to listen on this port.
-  listeningPorts: The Service is exposed on this port.
+  serviceListDescription: Services allow you to define a logical set of pods that can be accessed with a single IP address and port.
+  targetPorts: The service will send requests to this port, and the selected pods are expected to listen on this port.
+  listeningPorts: The service is exposed on this port.
   anyNode: Any Node
   labelsAnnotations:
     label: Labels & Annotations
@@ -4847,7 +4847,7 @@ servicesPage:
       placeholder: e.g. 10800
   externalName:
     define: External Name
-    helpText: "External Name is intended to specify a canonical DNS name. This is a required field. To hardcode an IP address, use a Headless service."
+    helpText: "External name is intended to specify a canonical DNS name. This is a required field. To hardcode an IP address, use a headless service."
     label: External Name
     placeholder: e.g. my.database.example.com
     input:
@@ -4892,7 +4892,7 @@ servicesPage:
   serviceTypes:
     clusterIp:
       abbrv: IP
-      description: Expose a set of Pods to other Pods within the cluster. This type of Service is only reachable from within the cluster. This is the default type.
+      description: Expose a set of pods to other pods within the cluster. This type of service is only reachable from within the cluster. This is the default type.
       label: Cluster IP
     externalName:
       abbrv: EN
@@ -4917,7 +4917,7 @@ setup:
   currentPassword: Bootstrap Password
   confirmPassword: Confirm New Password
   defaultPassword:
-    intro: It looks like this is your first time visiting {vendor}; if you pre-set your own bootstrap password, enter it here.  Otherwise a random one has been generated for you.  To find it:<br/><br/>
+    intro: It looks like this is your first time visiting {vendor}; if you have pre-set your own bootstrap password, enter it here. Otherwise a random one has been generated for you. To find it:<br/><br/>
     dockerPrefix: 'For a "docker run" installation:'
     dockerPs: 'Find your container ID with <code>docker ps</code>, then run:'
     dockerSuffix: ""
@@ -5277,7 +5277,7 @@ tableHeaders:
   apiGroup: API Groups
   apikey: API Key
   available: Available
-  attachedVM: Attached VM
+  attachedVM: Attached Virtual Machine
 
   authRoles:
     globalDefault: New User Default
@@ -5380,7 +5380,7 @@ tableHeaders:
   namespaceName: Name
   namespaceNameUnlinked: Name
   networkType: Type
-  networkVlan: Vlan ID
+  networkVlan: VLAN ID
   node: Node
   nodeName: Node Name
   nodesReady: Nodes Ready
@@ -5548,7 +5548,7 @@ validation:
     name: Cluster name cannot be 'local' or take the form 'c-xxxxx'
   conflict: |-
     This resource has been modified since you started editing it, and some of those modifications conflict with your changes.
-    This screen has been updated to reflect the current values on the cluster. Review and reapply the changes you wanted to make, then Save again.
+    This screen has been updated to reflect the current values on the cluster. Review and reapply the changes you wanted to make, then save again.
     Conflicting {fieldCount, plural, =1 {field} other {fields}}: {fields}
   custom:
     missing: 'No validator exists for { validatorName }! Does the validator exist in custom-validators? Is the name spelled correctly?'
@@ -5577,7 +5577,7 @@ validation:
     global: Requires "Cluster Output" to be selected.
   output:
     logdna:
-      apiKey: Required an "Api Key" to be set.
+      apiKey: Required an "API Key" to be set.
   invalidCron: Invalid cron schedule
   k8s:
     name: Must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name', or '123-abc').
@@ -5617,17 +5617,17 @@ validation:
   port: A port must be a number between 1 and 65535.
   path: '"{key}" must be an absolute path'
   prometheusRule:
-    noEdit: This Prometheus Rule may not be edited due to invalid characters in name.
+    noEdit: This Prometheus rule may not be edited due to invalid characters in name.
     groups:
       required: At least one rule group is required.
       singleAlert: A rule may contain alert rules or recording rules but not both.
       valid:
         name: 'Name is required for rule group {index}.'
         rule:
-          alertName: 'Rule group {groupIndex} rule {ruleIndex} requires a Alert Name.'
-          expr: 'Rule group {groupIndex} rule {ruleIndex} requires a PromQL Expression.'
+          alertName: 'Rule group {groupIndex} rule {ruleIndex} requires a alert name.'
+          expr: 'Rule group {groupIndex} rule {ruleIndex} requires a PromQL expression.'
           labels: 'Rule group {groupIndex} rule {ruleIndex} requires at least one label. Severity is recommended.'
-          recordName: 'Rule group {groupIndex} rule {ruleIndex} requires a Time Series Name.'
+          recordName: 'Rule group {groupIndex} rule {ruleIndex} requires a time series name.'
         singleEntry: 'At least one alert rule or one recording rule is required in rule group {index}.'
   required: '"{key}" is required'
   invalid: '"{key}" is invalid'
@@ -5636,12 +5636,12 @@ validation:
   roleTemplate:
     roleTemplateRules:
       missingVerb: You must specify at least one verb for each resource grant
-      missingResource: You must specify a Resource for each resource grant
-      missingApiGroup: You must specify an API Group for each resource grant
-      missingOneResource: You must specify at least one Resource, Non-Resource URL or API Group for each resource grant
+      missingResource: You must specify a resource for each resource grant
+      missingApiGroup: You must specify an API group for each resource grant
+      missingOneResource: You must specify at least one resource, non-resource URL or API group for each resource grant
   service:
     externalName:
-      none: External Name is required on an ExternalName Service.
+      none: External name is required on an ExternalName service.
     ports:
       name:
         required: 'Port Rule [{position}] - Name is required.'
@@ -5669,7 +5669,7 @@ validation:
     missingProjectId: A target must have a project selected.
   monitoring:
     route:
-      match: At least one Match or Match Regex must be selected
+      match: At least one match or match regex must be selected
       interval: '"{key}" must be of a format with digits followed by a unit i.e. 1h, 2m, 30s'
   tab: "One or more fields in this tab contain a form validation error"
 
@@ -5761,9 +5761,9 @@ workload:
       initialDelay: Initial Delay
       livenessProbe: Liveness Check
       livenessTip: Containers will be restarted when this check is failing.  Not recommended for most uses.
-      noHealthCheck: "There is not a Readiness Check, Liveness Check or Startup Check configured."
+      noHealthCheck: "There is not a readiness check, liveness check or startup check configured."
       readinessProbe: Readiness Checks
-      readinessTip: Containers will be removed from service endpoints when this check is failing.  Recommended.
+      readinessTip: Containers will be removed from service endpoints when this check is failing. Recommended.
       startupProbe: Startup Check
       startupTip: Containers will wait until this check succeeds before attempting other health checks.
       successThreshold: Success Threshold
@@ -5829,9 +5829,9 @@ workload:
     noServiceAccess: You do not have permission to create or manage services
     ports:
       expose: Networking
-      description: 'Define a Service to expose the container, or define a non-functional, named port so that humans will know where the app within the container is expected to run.'
-      detailedDescription: If ClusterIP, LoadBalancer, or NodePort is selected, a Service is automatically created that will select the Pods in this workload using labels.
-      toolTip: 'For help exposing workloads on Kubernetes, see the official Kubernetes documentation on Services. You can also manually create a Service to expose Pods by selecting their labels, and you can use an Ingress to map HTTP routes to Services.'
+      description: 'Define a service to expose the container, or define a non-functional, named port so that other users will know where the application within the container is expected to run.'
+      detailedDescription: If ClusterIP, LoadBalancer, or NodePort is selected, a service is automatically created that will select the pods in this workload using labels.
+      toolTip: 'For help exposing workloads on Kubernetes, see the official Kubernetes documentation on services. You can also manually create a service to expose pods by selecting their labels, and you can use an ingress to map HTTP routes to services.'
       createService: Service Type
       noCreateService: Do not create a service
       containerPort: Private Container Port
@@ -5905,13 +5905,13 @@ workload:
   detail:
     services: Services
     ingresses: Ingresses
-    cannotViewServices: Could not list Services due to lack of permission.
-    cannotFindServices: Could not find any Services that select Pods from this workload.
-    serviceListCaption: "The following Services select Pods from this workload:"
-    cannotViewIngresses: Could not list Ingresses due to lack of permission.
-    cannotFindIngresses: Could not find any Ingresses that forward traffic to Services that select Pods in this workload.
-    ingressListCaption: "The following Ingresses forward traffic to Services that select Pods from this workload:"
-    cannotViewIngressesBecauseCannotViewServices: Could not find relevant relevant Ingresses due to lack of permission to view Services.
+    cannotViewServices: Could not list services due to lack of permission.
+    cannotFindServices: Could not find any services that select pods from this workload.
+    serviceListCaption: "The following services select pods from this workload:"
+    cannotViewIngresses: Could not list ingresses due to lack of permission.
+    cannotFindIngresses: Could not find any ingresses that forward traffic to services that select pods in this workload.
+    ingressListCaption: "The following ingresses forward traffic to services that select pods from this workload:"
+    cannotViewIngressesBecauseCannotViewServices: Could not find relevant relevant ingresses due to lack of permission to view services.
     pods:
       title: Pods
   detailTop:
@@ -6100,7 +6100,7 @@ workload:
     addMount: Add Mount
     addVolume: Add Volume
     selectVolume: Select Volume
-    noVolumes: Volumes will appear here after they are added in the Pod tab
+    noVolumes: Volumes will appear here after they are added in the pod tab
     certificate: Certificate
     csi:
       diskName: Disk Name
@@ -6131,12 +6131,12 @@ workload:
     defaultMode: Default Mode
     driver: driver
     hostPath:
-      label: The Path on the Node must be
+      label: The Path on the node must be
       options:
         default: 'Anything: do not check the target path'
-        directoryOrCreate: A directory, or create if it doesn't exist
+        directoryOrCreate: A directory, or create if it does not exist
         directory: An existing directory
-        fileOrCreate: A file, or create if it doesn't exist
+        fileOrCreate: A file, or create if it does not exist
         file: An existing file
         socket: An existing socket
         charDevice: An existing character device
@@ -6165,11 +6165,11 @@ workload:
         placeholder: "e.g. 300"
   typeDescriptions:
     apps.daemonset: DaemonSets run exactly one pod on every eligible node. When new nodes are added to the cluster, DaemonSets automatically deploy to them. Recommended for system-wide or vertically-scalable workloads that never need more than one pod per node.
-    apps.deployment: Deployments run a scalable number of replicas of a pod distributed among the eligible nodes. Changes are rolled out incrementally and can be rolled back to the previous revision when needed. Recommended for stateless & horizontally-scalable workloads.
+    apps.deployment: Deployments run a scalable number of replicas of a pod distributed among the eligible nodes. Changes are rolled out incrementally and can be rolled back to the previous revision when needed. Recommended for stateless and horizontally-scalable workloads.
     apps.statefulset: StatefulSets manage stateful applications and provide guarantees about the ordering and uniqueness of the pods created. Recommended for workloads with persistent storage or strict identity, quorum, or upgrade order requirements.
-    batch.cronjob: CronJobs create Jobs, which then run Pods, on a repeating schedule. The schedule is expressed in standard Unix cron format, and uses the timezone of the Kubernetes control plane (typically UTC).
+    batch.cronjob: CronJobs create jobs, which then run pods, on a repeating schedule. The schedule is expressed in standard Unix cron format, and uses the timezone of the Kubernetes control plane (typically UTC).
     batch.job: Jobs create one or more pods to reliably perform a one-time task by running a pod until it exits successfully. Failed pods are automatically replaced until the specified number of completed runs has been reached. Jobs can also run multiple pods in parallel or function as a batch work queue.
-    pod: Pods are the smallest deployable units of computing that you can create and manage in Kubernetes. A Pod is a group of one or more containers, with shared storage and network resources, and a specification for how to run the containers.
+    pod: Pods are the smallest deployable units of computing that you can create and manage in Kubernetes. A pod is a group of one or more containers, with shared storage and network resources, and a specification for how to run the containers.
   upgrading:
     activeDeadlineSeconds:
       label: Pod Active Deadline
@@ -6178,8 +6178,8 @@ workload:
       label: Concurrency
       options:
         allow: Allow CronJobs to run concurrently
-        forbid: Skip next run if current run hasn't finished
-        replace: Replace run if current run hasn't finished
+        forbid: Skip next run if current run has not finished
+        replace: Replace run if current run has not finished
     maxSurge:
       label: Max Surge
       tip: The maximum number of pods allowed beyond the desired scale at any given time.
@@ -6201,7 +6201,7 @@ workload:
       labels:
         delete: "On Delete: New pods are only created when old pods are manually deleted."
         recreate: "Recreate: Kill ALL pods, then start new pods."
-        rollingUpdate: "Rolling Update: Create new pods, until max surge is reached, before deleting old pods. Don't stop more pods than max unavailable."
+        rollingUpdate: "Rolling Update: Create new pods, until max surge is reached, before deleting old pods. Do not stop more pods than max unavailable."
     terminationGracePeriodSeconds:
       label: Termination Grace Period
       tip: The duration the pod needs to terminate successfully.
@@ -6298,24 +6298,24 @@ typeDescription:
   cis.cattle.io.clusterscanprofile: A profile is the configuration for the CIS scan, which is the benchmark versions to use and any specific tests to skip in that benchmark.
   cis.cattle.io.clusterscan: A scan is created to trigger a CIS scan on the cluster based on the defined profile. A report is created after the scan is completed.
   cis.cattle.io.clusterscanreport: A report is the result of a CIS scan of the cluster.
-  management.cattle.io.feature: Feature Flags allow certain {vendor} features to be toggled on and off.  Features that are off by default should be considered experimental functionality.
-  cluster.x-k8s.io.machine: A Machine encapsulates the configuration of a Kubernetes Node. Use this view to see what happens after updating a cluster.
-  cluster.x-k8s.io.machinedeployment: A Machine Deployment orchestrates deployments via templates over a collection of Machine Sets (similar to a Deployment). Use this view to see what happens after updating a cluster.
-  cluster.x-k8s.io.machineset: A Machine Set ensures the desired number of Machine resources are up and running at all times (similar to a ReplicaSet). Use this view to see what happens after updating a cluster.
+  management.cattle.io.feature: Feature flags allow certain {vendor} features to be toggled on and off. Features that are off by default should be considered experimental functionality.
+  cluster.x-k8s.io.machine: A machine encapsulates the configuration of a Kubernetes node. Use this view to see what happens after updating a cluster.
+  cluster.x-k8s.io.machinedeployment: A machine deployment orchestrates deployments via templates over a collection of machine sets (similar to a deployment). Use this view to see what happens after updating a cluster.
+  cluster.x-k8s.io.machineset: A machine set ensures the desired number of machine resources are up and running at all times (similar to a ReplicaSet). Use this view to see what happens after updating a cluster.
   resources.cattle.io.backup: A backup is created to perform one-time backups or schedule recurring backups based on a ResourceSet.
   resources.cattle.io.restore: A restore is created to trigger a restore to the cluster based on a backup file.
   resources.cattle.io.resourceset: A resource set defines which CRDs and resources to store in the backup.
   monitoring.coreos.com.servicemonitor: A service monitor defines the group of services and the endpoints that Prometheus will scrape for metrics. This is the most common way to define metrics collection.
-  monitoring.coreos.com.podmonitor: A pod monitor defines the group of pods that Prometheus will scrape for metrics. The common way is to use service monitors, but pod monitors allow you to handle any situation where a service monitor wouldn't work.
-  monitoring.coreos.com.prometheusrule: A Prometheus Rule resource defines both recording and/or alert rules. A recording rule can pre-compute values and save the results. Alerting rules allow you to define conditions on when to send notifications to AlertManager.
+  monitoring.coreos.com.podmonitor: A pod monitor defines the group of pods that Prometheus will scrape for metrics. The common way is to use service monitors, but pod monitors allow you to handle any situation where a service monitor would not work.
+  monitoring.coreos.com.prometheusrule: A Prometheus rule resource defines both recording or alert rules. A recording rule can pre-compute values and save the results. Alerting rules allow you to define conditions on when to send notifications to AlertManager.
   monitoring.coreos.com.prometheus: A Prometheus server is a Prometheus deployment whose scrape configuration and rules are determined by selected ServiceMonitors, PodMonitors, and PrometheusRules and whose alerts will be sent to all selected Alertmanagers with the custom resource's configuration.
   monitoring.coreos.com.alertmanager: An alert manager is deployment whose configuration will be specified by a secret in the same namespace, which determines which alerts should go to which receiver.
-  node: The base Kubernetes Node resource represents a virtual or physical machine which hosts deployments. To manage the machine lifecycle, if available, go to Cluster Management.
+  node: The base Kubernetes node resource represents a virtual or physical machine which hosts deployments. To manage the machine lifecycle, if available, go to Cluster Management.
   catalog.cattle.io.clusterrepo: 'A chart repository is a Helm repository or {vendor} git based application catalog. It provides the list of available charts in the cluster.'
-  catalog.cattle.io.clusterrepo.local: ' A chart repository is a Helm repository or {vendor} git based application catalog. It provides the list of available charts in the cluster. Cluster Templates are deployed via Helm charts.'
+  catalog.cattle.io.clusterrepo.local: 'A chart repository is a Helm repository or {vendor} git based application catalog. It provides the list of available charts in the cluster. Cluster Templates are deployed via Helm charts.'
   catalog.cattle.io.operation: An operation is the list of recent Helm operations that have been applied to the cluster.
   catalog.cattle.io.app: An installed application is a Helm 3 chart that was installed either via our charts or through the Helm CLI.
-  logging.banzaicloud.io.clusterflow: Logs from the cluster will be collected and logged to the selected Cluster Output.
+  logging.banzaicloud.io.clusterflow: Logs from the cluster will be collected and logged to the selected cluster output.
   logging.banzaicloud.io.clusteroutput: A cluster output defines which logging providers that logs can be sent to and is only effective when deployed in the namespace that the logging operator is in.
   logging.banzaicloud.io.flow: A flow defines which logs to collect and filter as well as which output to send the logs. The flow is a namespaced resource, which means logs will only be collected from the namespace that the flow is deployed in.
   logging.banzaicloud.io.output: An output defines which logging providers that logs can be sent to. The output needs to be in the same namespace as the flow that is using it.
@@ -6349,8 +6349,8 @@ typeLabel:
     }
   catalog.cattle.io.app: |-
     {count, plural,
-      one { Installed App }
-      other { Installed Apps }
+      one { Installed Application }
+      other { Installed Applications }
     }
   catalog.cattle.io.clusterrepo: |-
     {count, plural,
@@ -6359,18 +6359,18 @@ typeLabel:
     }
   catalog.cattle.io.repo: |-
     {count, plural,
-      one { Namespaced Repo }
-      other { Namespaced Repos }
+      one { Namespaced Repository }
+      other { Namespaced Repositories }
     }
   chartinstallaction: |-
     {count, plural,
-      one { App }
-      other { Apps }
+      one { Application }
+      other { Applications }
     }
   chartupgradeaction: |-
     {count, plural,
-      one { App }
-      other { Apps }
+      one { Application }
+      other { Applications }
     }
   cloudcredential: |-
     {count, plural,
@@ -6394,8 +6394,8 @@ typeLabel:
     }
   fleet.cattle.io.gitrepo: |-
     {count, plural,
-      one { Git Repo }
-      other {Git Repos }
+      one { Git Repository }
+      other {Git Repositories }
     }
   management.cattle.io.authconfig: |-
     {count, plural,
@@ -6500,8 +6500,8 @@ typeLabel:
     }
   'management.cattle.io.cluster': |-
     {count, plural,
-      one { Mgmt Cluster }
-      other { Mgmt Clusters }
+      one { Manaagement Cluster }
+      other { Management Clusters }
     }
   'cluster.x-k8s.io.cluster': |-
     {count, plural,
@@ -6680,8 +6680,8 @@ typeLabel:
     }
   harvesterhci.io.cloudtemplate: |-
     {count, plural,
-      one { Cloud Config Template }
-      other { Cloud Config Templates }
+      one { Cloud Configuration Template }
+      other { Cloud Configuration Templates }
     }
   fleet.cattle.io.content: |-
     {count, plural,
@@ -6700,8 +6700,8 @@ typeLabel:
     }
   k3s.cattle.io.addon: |-
     {count, plural,
-      one { Addon }
-      other { Addons }
+      one { Add-on }
+      other { Add-ons }
     }
   management.cattle.io.apiservice: |-
     {count, plural,
@@ -6920,7 +6920,7 @@ keyValue:
 
 registryMirror:
   header: Mirrors
-  toolTip: 'Mirrors can be used to redirect requests for images from one registry to come from a list of endpoints you specify instead.  For example docker.io could redirect to your internal registry instead of ever going to DockerHub.'
+  toolTip: 'Mirrors can be used to redirect requests for images from one registry to come from a list of endpoints you specify instead. For example docker.io could redirect to your internal registry instead of ever going to DockerHub.'
   addLabel: Add Mirror
   description: Mirrors define the names and endpoints for private registries. The endpoints are tried one by one, and the first working one is used.
   hostnameLabel: Registry Hostname
@@ -6968,12 +6968,12 @@ advancedSettings:
     'cluster-defaults': 'Override RKE Defaults when creating new clusters.'
     'engine-install-url': 'Default Docker engine installation URL (for most node drivers).'
     'engine-iso-url': 'Default OS installation URL (for vSphere driver).'
-    'engine-newest-version': 'The newest supported version of Docker at the time of this release.  A Docker version that does not satisfy supported docker range but is newer than this will be marked as untested.'
-    'engine-supported-range': 'Semver range for supported Docker engine versions.  Versions which do not satisfy this range will be marked unsupported in the UI.'
-    'ingress-ip-domain': 'Wildcard DNS domain to use for automatically generated Ingress hostnames. <ingress-name>.<namespace-name>.<ip address of ingress controller> will be added to the domain.'
+    'engine-newest-version': 'The newest supported version of Docker at the time of this release. A Docker version that does not satisfy supported docker range but is newer than this will be marked as untested.'
+    'engine-supported-range': 'Semver range for supported Docker engine versions. Versions which do not satisfy this range will be marked unsupported in the UI.'
+    'ingress-ip-domain': 'Wildcard DNS domain to use for automatically generated ingress hostnames. <ingress-name>.<namespace-name>.<ip address of ingress controller> will be added to the domain.'
     'server-url': 'Default {appName} install url. Must be HTTPS. All nodes in your cluster must be able to reach this.'
-    'system-default-registry': 'Private registry to be used for all Rancher System Container Images. If no value is specified, the default registry for the container runtime is used. For Docker and containerd, the default is `docker.io`.'
-    'ui-index': 'HTML index location for the Cluster Manager UI.'
+    'system-default-registry': 'Private registry to be used for all Rancher system container images. If no value is specified, the default registry for the container runtime is used. For Docker and containerd, the default is `docker.io`.'
+    'ui-index': 'HTML index location for the cluster manager UI.'
     'ui-dashboard-index': 'HTML index location for the {appName} UI.'
     'ui-offline-preferred': 'Controls whether UI assets are served locally by the server container or from the remote URL defined in the ui-index and ui-dashboard-index settings. The `Dynamic` option will use local assets in production builds of {appName}.'
     'ui-pl': 'Private-Label company name.'
@@ -7038,19 +7038,19 @@ performance:
     label: Incremental Loading
     setting: You can configure the threshold above which incremental loading will be used.
     description: |-
-      When enabled, resources will appear more quickly, but it may take slightly longer to load the entire set of resources. This setting only applies to resources that come from the Kubernetes API
+      When enabled, resources will appear more quickly, but it may take slightly longer to load the entire set of resources. This setting only applies to resources that come from the Kubernetes API.
     checkboxLabel: Enable incremental loading
     inputLabel: Resource Threshold
-    incompatibleDescription: "Incremental Loading is incomaptible with Namespace/Project filtering. Enabling this will disable it."
+    incompatibleDescription: "Incremental Loading is incomaptible with namespace or project filtering. Enabling this will disable it."
   manualRefresh:
     label: Manual Refresh
     setting: You can configure a threshold above which manual refresh will be enabled.
     buttonTooltip: Refresh list
     description: |-
-      When enabled, list data will not auto-update but instead the user must manually trigger a list-view refresh. This setting only applies to resources that come from the Kubernetes API
+      When enabled, list data will not auto-update but instead the user must manually trigger a list-view refresh. This setting only applies to resources that come from the Kubernetes API.
     checkboxLabel: Enable manual refresh of data for lists
     inputLabel: Resource Threshold
-    incompatibleDescription: "Manual Refresh is incomaptible with Namespace/Project filtering. Enabling this will disable it."
+    incompatibleDescription: "Manual Refresh is incomaptible with namespace or project filtering. Enabling this will disable it."
   websocketNotification:
     label: Websocket Notifications
     description: |-
@@ -7058,7 +7058,7 @@ performance:
     checkboxLabel: Disable websocket notifications
   gc:
     label: Resource Garbage Collection
-    description: The UI will cache kuberentes resources locally to avoid having to re-fetch them. In some cases this can lead to a large amount of data stored in the browser. Enable this setting to periodically remove them.
+    description: The UI will cache Kuberentes resources locally to avoid having to re-fetch them. In some cases, this can lead to a large amount of data stored in the browser. Enable this setting to periodically remove them.
     checkboxLabel: Enable Garbage Collection
     whenRun:
       description: Update when garbage collection runs
@@ -7072,25 +7072,25 @@ performance:
     howRun:
       description: Update how garbage collection runs
       age:
-        description: "Resource types musn't have been accessed within this period to be considered for garbage collection."
+        description: "Resource types must not have been accessed within this period to be considered for garbage collection."
         inputLabel: Resource Age
       count:
         description: Resource types must exceed this amount to be considered for garbage collection.
         inputLabel: Resource Count
   nsFiltering:
     label: Require Namespace / Project Filtering
-    description: Require the user to select namespaces and/or projects. This restricts the number of resources fetched when viewing lists and should help the responsiveness of the UI in systems with a lot of resources.
-    checkboxLabel: Enable Required Namespace / Project Filtering
-    incompatibleDescription: "Required Namespace / Project Filtering is incomaptible with Manual Refresh and Incremental Loading. Enabling this will disable them."
+    description: Require the user to select namespaces or projects. This restricts the number of resources fetched when viewing lists and should help the responsiveness of the UI in systems with a lot of resources.
+    checkboxLabel: Enable Required Namespace or Project Filtering
+    incompatibleDescription: "Required namespace or project filtering is incomaptible with manual refresh and incremental Loading. Enabling this will disable them."
   advancedWorker:
     label: Websocket Web Worker
-    description: Updates to resources pushed to the UI come via WebSocket and are handled in the UI thread. Enable this option to handle cluster WebSocket updates in a Web Worker in a separate thread. This should help the responsiveness of the UI in systems where resources change often.
+    description: Updates to resources pushed to the UI come via WebSocket and are handled in the UI thread. Enable this option to handle cluster WebSocket updates in a web worker in a separate thread. This should help the responsiveness of the UI in systems where resources change often.
     checkboxLabel: Enable Advanced Websocket Web Worker
   inactivity:
     title: Inactivity
     checkboxLabel: Enable inactivity session expiration
     inputLabel: Inactivity timeout (minutes)
-    information: To change the automatic logout behaviour, edit the authorisation and/or session token timeout values (<code>auth-user-session-ttl-minutes</code> and <code>auth-token-max-ttl-minutes</code>) in the Settings page.
+    information: To change the automatic log out behaviour, edit the authorisation and session token timeout values (<code>auth-user-session-ttl-minutes</code> and <code>auth-token-max-ttl-minutes</code>) in the settings page.
     description: When enabled and the user is inactive past the specified timeout, the UI will no longer fresh page content and the user must reload the page to continue.
     authUserTTL: This timeout cannot be higher than the user session timeout auth-user-session-ttl-minutes, which is currently {current} minutes.
 
@@ -7261,8 +7261,8 @@ support:
       text: Login to SUSE Customer Center to access support for your subscription
       action: SUSE Customer Center
       aws:
-        generateConfig: Generate Support Config
-        text: 'Login to SUSE Customer Center to access support for your subscription. Need to open a new support case? Download a support config file below.'
+        generateConfig: Generate Support Configuration
+        text: 'Login to SUSE Customer Center to access support for your subscription. Need to open a new support case? Download a support configuration file below.'
   promos:
     one:
       title: 24x7 Support
@@ -7307,7 +7307,7 @@ legacy:
 
   project:
     label: Project
-    select: "Use the Project/Namespace filter at the top of the page to select a Project in order to see legacy Project features."
+    select: "Use the namespace or project filter at the top of the page to select a project in order to see legacy project features."
 
 serverUpgrade:
   title: "{vendor} Server Changed"

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -101,7 +101,7 @@ generic:
 
   deprecated: Deprecated
   placeholder: "e.g. {text}"
-  moreInfo: More Info
+  moreInfo: More Information
   selectors:
     label: Selector
     matchingResources:
@@ -195,7 +195,7 @@ nav:
     restoreCards: Restore hidden cards
   userMenu:
     preferences: Preferences
-    accountAndKeys: Account & API Keys
+    accountAndKeys: Account and API Keys
     logOut: Log Out
   failWhale:
     reload: Reload
@@ -203,7 +203,7 @@ nav:
 
 product:
   apps: Apps
-  auth: Users & Authentication
+  auth: Users and Authentication
   backup: Rancher Backups
   cis: CIS Benchmark
   ecm: Cluster Manager
@@ -337,17 +337,17 @@ accountAndKeys:
       accessKey: Access Key
       secretKey: Secret Key
       bearerToken: Bearer Token
-      saveWarning: Save the info above! This is the only time you'll be able to see it. If you lose it, you'll need to create a new API key.
-      keyCreated: A new API Key has been created
-      bearerTokenTip: "Access Key and Secret Key can be sent as the username and password for HTTP Basic auth to authorize requests. You can also combine them to use as a Bearer token:"
-      ttlLimitedWarning: The Expiry time for this API Key was reduced due to system configuration
+      saveWarning: Save the above information! This is the only time you will be able to see it. If you lose it, you will need to create a new API key.
+      keyCreated: A new API key has been created
+      bearerTokenTip: "Access Key and Secret Key can be sent as the username and password for HTTP basic authentication to authorize requests. You can also combine them to use as a Bearer token:"
+      ttlLimitedWarning: The Expiry time for this API key was reduced due to system configuration
 
 addClusterMemberDialog:
   title: Add Cluster Member
 
 addonConfigConfirmation:
   title: Add-On Config Reset
-  body: Changing the Kubernetes Version can reset the Add-On Config values. You should check that the values are as expected before continuing.
+  body: Changing the Kubernetes Version can reset the add-on configuration values. Confirm that the values are as expected before continuing.
 
 addProjectMemberDialog:
   title: Add Project Member
@@ -355,11 +355,11 @@ addProjectMemberDialog:
 authConfig:
   accessMode:
     label: 'Configure who should be able to login and use {vendor}'
-    required: Restrict access to only the authorized users & groups
-    restricted: 'Allow members of clusters and projects, plus authorized users & groups'
+    required: Restrict access to only the authorized users and groups
+    restricted: 'Allow members of clusters and projects, plus authorized users and groups'
     unrestricted: Allow any valid user
   allowedPrincipalIds:
-    title: Authorized Users & Groups
+    title: Authorized Users and Groups
   associatedWarning: 'Note: The {provider} user you authenticate as will be associated as an alternate way to login to the {vendor} user you are currently logged in as <code>{username}</code>; all the global permissions, project, and cluster role bindings of this {vendor} user will also apply to the {provider} user.'
   github:
     clientId:
@@ -384,7 +384,7 @@ authConfig:
         3: <li>Click the "New OAuth App" button.</li>
       suffix:
         1: <li>Click "Register application"</li>
-        2: <li>Copy and paste the Client ID and Client Secret of your newly created OAuth app into the fields below</li>
+        2: <li>Copy and paste the client ID and client secret of your newly created OAuth app into the fields below</li>
     host:
       label: GitHub Enterprise Host
       placeholder: e.g. github.mycompany.example
@@ -408,7 +408,7 @@ authConfig:
       1:
         title: 'Click <a href="https://console.developers.google.com/apis/credentials" target="_blank" rel="noopener noreferrer nofollow">here</a> to open applications settings in a new window'
         body:
-         1: Login to your account. Navigate to "APIs & Services" and then select "OAuth consent screen".
+         1: Login to your account. Navigate to "APIs and Services" and then select "OAuth consent screen".
          2: 'Authorized domains:'
          3: 'Application homepage link: '
          4: 'Under Scopes for Google APIs, enable "email", "profile", and "openid".'
@@ -417,7 +417,7 @@ authConfig:
       2:
         title: 'Navigate to the "Credentials" tab to create your OAuth client ID'
         body:
-          1: 'Select the "Create Credentials" dropdown, and select "OAuth clientID", then select "Web application".'
+          1: 'Select the "Create Credentials" drop-down, and select "OAuth clientID", then select "Web application".'
           2: 'Authorized Javascript origins:'
           3: 'Authorized redirect URIs:'
           4: 'Click "Create", and then click on the "Download JSON" button.'
@@ -428,14 +428,14 @@ authConfig:
         body:
           1: Create a service account.
           2: Generate a key for the service account.
-          3: Add the service account as an OAuth client in your google domain.
+          3: Add the service account as an OAuth client in your Google domain.
   ldap:
     freeipa: Configure a FreeIPA server
     activedirectory: Configure an Active Directory account
     openldap: Configure an OpenLDAP server
     defaultLoginDomain:
       label: Default Login Domain
-      placeholder: eg mycompany
+      placeholder: eg, mycompany
       hint: This domain will be used if a user logs in without specifying one.
     cert: Certificate
     disabledStatusBitmask: Disabled Status Bitmask
@@ -728,7 +728,7 @@ backupRestoreOperator:
   backupFilename: Backup Filename
   deleteTimeout:
     label: Delete Timeout
-    tip: Seconds to wait for a resource delete to succeed before removing finalizers to force deletion.
+    tip: Seconds to wait for a resource deletion to succeed before removing finalizers to force deletion.
   deployment:
     rancherNamespace: Rancher ResourceSet Namespace
     size: Size
@@ -745,14 +745,14 @@ backupRestoreOperator:
       storageClass:
         label: Storage Class
       tip: 'Configure a storage location where all backups are saved by default. You will have the option to override this with each backup, but will be limited to using an S3-compatible object store.'
-      warning: 'This {type} does not have its reclaim policy set to "Retain".  Your backups may be lost if the volume is changed or becomes unbound.'
+      warning: 'This {type} does not have its reclaim policy set to "Retain". Your backups may be lost if the volume is changed or becomes unbound.'
   encryption: Encryption
   encryptionConfigName:
     backuptip: 'Any secret in the <code>cattle-resource-system</code> namespace that has an <code>encryption-provider-config.yaml</code> key. <br/>The contents of this file are necessary to perform a restore from this backup, and are not stored by Rancher Backup.'
     label: Encryption Config Secret
     options:
       none: Store the contents of the backup unencrypted
-      secret: 'Encrypt backups using an <a target="_blank" rel="noopener noreferrer nofollow" href="https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#understanding-the-encryption-at-rest-configuration">Encryption Config Secret</a> (Recommended)'
+      secret: 'Encrypt backups using an <a target="_blank" rel="noopener noreferrer nofollow" href="https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#understanding-the-encryption-at-rest-configuration">Encryption Configuration Secret</a> (Recommended)'
     restoretip: 'If the backup was performed with encryption enabled, a secret containing the same encryption-provider-config should be used during restore.'
     warning: 'The contents of this file are necessary to perform a restore from this backup, and are not stored by Rancher Backup.'
   lastBackup: Last Backup
@@ -852,9 +852,9 @@ catalog:
     versionWindowsIncompatible: Linux only version
     header: Charts
     featuredCharts: Featured Charts
-    noCharts: 'There are no charts available, have you added any repos?'
-    noWindows: Your repos do not contain any charts capable of being deployed on a cluster with Windows nodes.
-    noWindowsAndLinux: Your repos do not contain any charts capable of being deployed on a cluster with both Windows and Linux worker nodes.
+    noCharts: 'There are no charts available, have you added any repositories?'
+    noWindows: Your repositories do not contain any charts capable of being deployed on a cluster with Windows nodes.
+    noWindowsAndLinux: Your repositories do not contain any charts capable of being deployed on a cluster with both Windows and Linux worker nodes.
     operatingSystems:
       all: All Operating Systems
       linux: Linux
@@ -863,7 +863,7 @@ catalog:
   install:
     action:
       goToUpgrade: Edit/Upgrade
-    appReadmeMissing: This chart doesn't have any additional chart information.
+    appReadmeMissing: This chart does not have any additional chart information.
     appReadmeTitle: Chart Information (Helm README)
     chart: Chart
     error:
@@ -872,12 +872,12 @@ catalog:
       insufficientCpu: 'This chart requires {need, number} CPU cores, but the cluster only has {have, number} available.'
       insufficientMemory: 'This chart requires {need} of memory, but the cluster only has {have} available.'
       legacy:
-        label: This is a {legacyType} App and it cannot be modified here
+        label: This is a {legacyType} application and it cannot be modified here
         enableLegacy:
-          prompt: You will need to enable Legacy Features to edit this App
+          prompt: You will need to enable Legacy Features to edit this application
           goto: Go to Feature Flag settings
-        navigate: Navigate to Legacy Apps
-        mcmNotSupported: Legacy Multi-cluster Apps can not be managed through this UI
+        navigate: Navigate to Legacy Applications
+        mcmNotSupported: Legacy Multi-cluster Applications can not be managed through this UI
         category:
           legacy: Legacy
           mcm: Multi-cluster
@@ -889,8 +889,8 @@ catalog:
       atomic: Atomic
       description:
         label: Description
-        placeholder: e.g. Purpose of helm command
-      cleanupOnFail: Cleanup on Failure
+        placeholder: e.g. Purpose of Helm command
+      cleanupOnFail: Clean up on Failure
       crds: Apply custom resource definitions
       dryRun: Dry Run
       force: Force
@@ -913,7 +913,7 @@ catalog:
           }
       wait: Wait
     namespaceIsInProject: "This chart's target namespace, <code>{namespace}</code>, already exists and cannot be added to a different project."
-    project: Install into Project
+    project: Install Into Project
     section:
       chartOptions: Edit Options
       valuesYaml: Edit YAML
@@ -931,8 +931,8 @@ catalog:
           } the {existing, select,
             true { app}
             false { chart}
-          }. Start by setting some basic information used by {vendor} to manage the App.
-        nsCreationDescription: "To install the app into a new namespace enter it's name in the Namespace field and select it."
+          }. Start by setting some basic information used by {vendor} to manage the application.
+        nsCreationDescription: "To install the application into a new namespace, enter the name in the Namespace field and select it."
         createNamespace: "Namespace <code>{namespace}</code> will be created."
       clusterTplVersion:
         label: Version
@@ -940,19 +940,19 @@ catalog:
         description: Select a version of the Cluster Template
       clusterTplValues:
         label: Values
-        subtext: Change how the Cluster is defined
-        description: Configure Values used by Helm that help define the Cluster.
+        subtext: Change how the cluster is defined
+        description: Configure Values used by Helm that help define the cluster.
       helmValues:
         label: Values
-        subtext: Change how the App works
-        description: Configure Values used by Helm that help define the App.
+        subtext: Change how the application works
+        description: Configure values used by Helm that help define the application.
         chartInfo:
-          button: View Chart Info
-          label: Chart Info
+          button: View Chart Information
+          label: Chart Information
       helmCli:
-        checkbox: Customize Helm options before install
+        checkbox: Customize Helm options before installation
         label: Helm Options
-        subtext: Change how the app is deployed
+        subtext: Change how the application is deployed
         description: Supply additional deployment options
     version: Version
     versions:
@@ -971,7 +971,7 @@ catalog:
     gitBranch:
       label: Git Branch
       placeholder: e.g. master
-      defaultMessage: 'Will default to "master" if left blank'
+      defaultMessage: 'The branch will default to "master" if left blank'
     gitRepo:
       label: Git Repo URL
       placeholder: 'e.g. https://github.com/your-company/charts.git'
@@ -1103,7 +1103,7 @@ cluster:
     rke2-multus: Multus Configuration
   agentEnvVars:
     label: Agent Environment
-    detail: Add additional environment variables to the agent container.  This is most commonly useful for configuring a HTTP proxy.
+    detail: Add additional environment variables to the agent container. This is most commonly useful for configuring a HTTP proxy.
     keyLabel: Variable Name
   cloudProvider:
     aws:
@@ -1116,7 +1116,7 @@ cluster:
       label: Google
     rancher-vsphere:
       label: vSphere
-      note: '<b>Important:</b> Configure the vSphere Cloud Provider and Storage Provider options in the Add-On Config tab.'
+      note: '<b>Important:</b> Configure the vSphere Cloud Provider and Storage Provider options in the Add-On Configuration tab.'
     harvester:
       label: Harvester
   copyConfig: Copy KubeConfig to Clipboard
@@ -1124,10 +1124,10 @@ cluster:
   custom:
     nodeRole:
       label: Node Role
-      detail: Choose what roles the node will have in the cluster.  The cluster needs to have at least one node with each role.
+      detail: Choose what roles the node will have in the cluster. The cluster needs to have at least one node with each role.
     advanced:
       label: Advanced
-      detail: Additional control over how the node will be registered.  These values will often need to be different for each node registered.
+      detail: Additional control over how the node will be registered. These values will often need to be different for each node registered.
       nodeName: Node Name
       publicIp: Node Public IP
       privateIp: Node Private IP
@@ -1140,14 +1140,14 @@ cluster:
       windowsDetail: Run this command in PowerShell on each of the existing Windows machines you want to register. Windows nodes can only be workers.
       windowsNotReady: The cluster must be up and running with Linux etcd, control plane, and worker nodes before the registration command for adding Windows workers will display.
       windowsWarning: Workload pods, including some deployed by Rancher charts, will be scheduled on both Linux and Windows nodes by default. Edit NodeSelector in the chart to direct them to be placed onto a compatible node.
-      windowsDeprecatedForRKE1: Windows support is being deprecated for RKE1. We suggest migrating to RKE2.
+      windowsDeprecatedForRKE1: Windows support is being deprecated for RKE1 and RKE1 is soon to be deprecrated. Please migrate to RKE2.
       insecure: "Insecure: Select this to skip TLS verification if your server has a self-signed certificate."
   credential:
     banner:
       createCredential: |-
         {length, plural,
-          =0 {First you'll need to create a credential to talk to the cloud provider}
-          other {Ok, Let's create a new credential}
+          =0 {First, you will need to create a credential to talk to the cloud provider}
+          other {Ok, start to create a new credential}
         }
     selectExisting:
       label: Select Existing
@@ -1160,7 +1160,7 @@ cluster:
         label: Access Key
         placeholder: Your AWS Access Key
       defaultRegion:
-        help: The default region to use when creating clusters.  Also contacted to verify that this credential works.
+        help: The default region to use when creating clusters. Also contacted to verify that this credential works.
         label: Default Region
       secretKey:
         label: Secret Key
@@ -1265,7 +1265,7 @@ cluster:
         volume: Volume
         imageVolume: Image Volume
         addVolume: Add Volume
-        addVMImage: Add VM Image
+        addVMImage: Add Virtual Machine Image
         storageClass: Storage Class
       sshUser: SSH User
       userData:
@@ -1281,9 +1281,9 @@ cluster:
       installGuestAgent: Install guest agent
   description:
     label: Cluster Description
-    placeholder: Any text you want that better describes this cluster
+    placeholder: Any text to describe this cluster
   harvester:
-    importNotice: Import Harvester Clusters via
+    importNotice: Import Harvester Clusters Via
     warning:
       label: This is a Harvester Cluster - enable the Harvester feature flag to manage it
       state: Warning
@@ -1316,11 +1316,11 @@ cluster:
       sshUser:
         placeholder: e.g. ubuntu
         toolTip: SSH user to login with the selected OS image.
-  haveOneOwner: There must be at least one member with the Owner role.
+  haveOneOwner: There must be at least one member with the owner role.
   import:
     warningBanner: 'You should not import a cluster which has already been connected to another instance of Rancher as it will lead to data corruption.'
     commandInstructions: 'Run the <code>kubectl</code> command below on an existing Kubernetes cluster running a supported Kubernetes version to import it into {vendor}:'
-    commandInstructionsInsecure: 'If you get a &quot;certificate signed by unknown authority&quot; error, your {vendor} installation has a self-signed or untrusted SSL certificate.  Run the command below instead to bypass the certificate verification:'
+    commandInstructionsInsecure: 'If you get a &quot;certificate signed by unknown authority&quot; error, your {vendor} installation has a self-signed or untrusted SSL certificate. Run the command below instead to bypass the certificate verification:'
     clusterRoleBindingInstructions: 'If you get permission errors creating some of the resources, your user may not have the <code>cluster-admin</code> role.  Use this command to apply it:'
     clusterRoleBindingCommand: 'kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user <your username from your kubeconfig>'
   explore: Explore
@@ -1333,7 +1333,7 @@ cluster:
     deprecated: (deprecated)
     deprecatedPatches: Show deprecated Kubernetes patch versions
     deprecatedPatchWarning: We recommend using the latest patch version for each minor Kubernetes version. Deprecated patch versions can be useful for migration purposes.
-  toolsTip: Use the new Cluster Tools to manage and install Monitoring, Logging and other tools
+  toolsTip: Use the new cluster tools to manage and install monitoring, logging and other tools
   legacyWarning: The legacy feature flag is enabled and not all legacy features are supported in Kubernetes 1.21+.
   log:
     connecting: Connecting…
@@ -1411,14 +1411,14 @@ cluster:
         network: Network
         disks: Disks
       size:
-        label: VM Size
+        label: Virtual Machine Size
         tooltip: When accelerated networking is enabled, not all sizes are available.
-        supportsAcceleratedNetworking: Sizes that Support Accelerated Networking
+        supportsAcceleratedNetworking: Sizes That Support Accelerated Networking
         doesNotSupportAcceleratedNetworking: Sizes Without Accelerated Networking
-        availabilityWarning: The selected VM size is not available in the selected region.
+        availabilityWarning: The selected virtual machine size is not available in the selected region.
         regionDoesNotSupportAzs: Availability zones are not supported in the selected region. Please select a different region or use an availability set instead.
-        regionSupportsAzsButNotThisSize: The selected region does not support availability zones for the selected VM size. Please select a different region or VM size.
-        selectedSizeAcceleratedNetworkingWarning: The selected VM size does not support accelerated networking. Please select another VM size or disable accelerated networking.
+        regionSupportsAzsButNotThisSize: The selected region does not support availability zones for the selected virtual machine size. Please select a different region or virtual machine size.
+        selectedSizeAcceleratedNetworkingWarning: The selected virtual machine size does not support accelerated networking. Please select another virtual machine size or disable accelerated networking.
       sshUser:
         label: SSH Username
       storageType:
@@ -1511,7 +1511,7 @@ cluster:
         folder: Folder
         host:
           label: Host
-          note: Specific host to create VM on (leave blank for standalone ESXi or for cluster with DRS)
+          note: Specific host to create virtual machine on (leave blank for standalone ESXi or for cluster with DRS)
       instanceOptions:
         label: Instance Options
         description: Choose the size and OS of the virtual machine
@@ -1608,7 +1608,7 @@ cluster:
       serverOs:
         label: OS
   addOns:
-    dependencyBanner: Add-On Configurations can vary between Kubernetes versions. Changing the Kubernetes version may reset the values below.
+    dependencyBanner: Add-on configurations can vary between Kubernetes versions. Changing the Kubernetes version may reset the values below.
     additionalManifest:
       title: Additional Manifest
       tooltip: 'Additional Kubernetes Manifest YAML to be applied to the cluster on startup.'
@@ -1627,8 +1627,8 @@ cluster:
       nodeAffinity: Node Affinity
     banners:
       advanced: These are advanced configuration options. Generally, they should be left as-is.
-      tolerations: Additional Pod Tolerations will be added to the default Tolerations applied by Rancher.
-      limits: Pod Requests and Limits do not have a default configuration.
+      tolerations: Additional pod tolerations will be added to the default tolerations applied by Rancher.
+      limits: Pod requests and limits do not have a default configuration.
       windowsCompatibility: "We do not recommended removing the Node Affinity rule that prevents the <b>agent</b> from running on Windows nodes as this is not a supported configuration."
     affinity:
       default: Use default affinity rules defined by Rancher
@@ -1638,8 +1638,8 @@ cluster:
       title: Additional Kubelet Args
       machineSelector:
         label: Add Machine Selector
-        listLabel: Add Argument
-        bannerLabel: 'Note: The last selector that matches wins and only args from it will be used.  Args from other matches above will not combined together or merged.'
+        listLabel: Add Args
+        bannerLabel: 'Note: The last selector that matches wins and only args from it will be used. Args from other matches above will not combined together or merged.'
         title: 'For machines with labels matching:'
         subTitle: 'Use the Kubelet args:'
         titleAlt:  |-
@@ -1654,11 +1654,11 @@ cluster:
       label: Raise error if kernel parameters are different than the expected kubelet defaults
   banner:
     warning: 'This cluster contains a machineSelectorConfig which this form does not fully support; use the YAML editor to manage the full configuration.'
-    os: 'You are attemping to add a {newOS} worker node to a cluster with one or more {existingOS} worker nodes: some installed apps may need to be upgraded or removed.'
+    os: 'You are attemping to add a {newOS} worker node to a cluster with one or more {existingOS} worker nodes: some installed applications may need to be upgraded or removed.'
     rke2-k3-reprovisioning: 'Making changes to cluster configuration may result in nodes reprovisioning. For more information see the <a target="blank" href="{docsBase}/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/" target="_blank" rel="noopener nofollow">documentation</a>.'
     desiredNodeGroupWarning: There are 0 nodes available to run the cluster agent. The cluster will not become active until at least one node is available.
     invalidPsps: You have one or more PodSecurityPolicy resource(s) in this cluster. Pod Security Policies are not available in Kubernetes v1.25 and will be automatically removed.
-    haveArgInfo: Configuration information is not available for the selected Kubernetes version.  The options available in this screen will be limited, you may want to use the YAML editor.
+    haveArgInfo: Configuration information is not available for the selected Kubernetes version. The options available in this screen will be limited, you may want to use the YAML editor.
     deprecatedPsp: Pod Security Policies are deprecated as of Kubernetes v1.21, and have been removed in Kubernetes v1.25.
     removedPsp: Pod Security Policies have been removed in Kubernetes v1.25, use Pod Security Admission instead.
   rkeTemplateUpgrade: Template revision {name} available for upgrade
@@ -1678,7 +1678,7 @@ cluster:
   machinePool:
     name:
       label: Pool Name
-      placeholder: A random one will be generated by default
+      placeholder: A random name is generated by default
     nodeTotals:
       label:
         controlPlane: '{count} Control Plane'
@@ -1695,7 +1695,7 @@ cluster:
           {count, plural,
             =0 { A cluster needs at least one etcd node to be usable. }
             =1 { A cluster with only one etcd node is not fault-tolerant. }
-            =2 { Clusters should have an odd number of nodes.  A cluster with 2 etcd nodes is not fault-tolerant. }
+            =2 { Clusters should have an odd number of nodes. A cluster with 2 etcd nodes is not fault-tolerant. }
             =3 {}
             =4 { Clusters should have an odd number of nodes. }
             =5 {}
@@ -1731,7 +1731,7 @@ cluster:
       label: Auto Replace
       toolTip: If greater than 0, nodes that are unreachable for this duration will be automatically deleted and replaced.
       unit: "Seconds"
-  managementTimeout: The cluster to become available. It's possible the cluster was created. We suggest checking the clusters page before trying to create another.
+  managementTimeout: The cluster to become available. It is possible the cluster was created. We suggest checking the clusters page before trying to create another.
   memberRoles:
     removeMessage: 'Note: Removing a user will not remove their project permissions'
     addClusterMember:
@@ -1807,11 +1807,11 @@ cluster:
       harvester: '{tag}'
   providerGroup:
     create-custom1: Use existing nodes and create a cluster using RKE
-    create-custom2: Use existing nodes and create a cluster using RKE2/K3s
+    create-custom2: Use existing nodes and create a cluster using RKE2 or K3s
     create-kontainer: Create a cluster in a hosted Kubernetes provider
     register-kontainer: Register an existing cluster in a hosted Kubernetes provider
     create-rke1: Provision new nodes and create a cluster using RKE
-    create-rke2: Provision new nodes and create a cluster using RKE2/K3s
+    create-rke2: Provision new nodes and create a cluster using RKE2 or K3s
     create-template: Use a Catalog Template to create a cluster
     register-custom: Import any Kubernetes cluster
   rke2:
@@ -1835,7 +1835,7 @@ cluster:
       label: Container Network
     cloudProvider:
       label: Cloud Provider
-      header: Cloud Provider Config
+      header: Cloud Provider Configuration
       defaultValue:
         label: Default - RKE2 Embedded
     security:
@@ -1867,8 +1867,8 @@ cluster:
       toolTip: "This can be either a fixed number of nodes (e.g. 1) at a time or a percentage (e.g. 10%)"
     drain:
       label: Drain Nodes
-      toolTip: Draining preemptively removes the pods on each node so there are no running workloads on the nodes being upgraded.  Upgrading without draining is faster and causes less shuffling around, but pods may still be restarted depending on the upgrade being performed.
-    deleteEmptyDir: "By default, pods using emptyDir volumes will be deleted on upgrade. Operations reliant on emptyDir volumes persisting through the pod's lifecycle may be impacted."
+      toolTip: Draining preemptively removes the pods on each node so there are no running workloads on the nodes being upgraded. Upgrading without draining is faster and causes less shuffling around, but pods may still be restarted depending on the upgrade being performed.
+    deleteEmptyDir: "By default, pods using emptyDir volumes will be deleted on upgrade. Operations reliant on emptyDir volumes persisting through the pods lifecycle may be impacted."
     truncateHostnames: Truncate hostnames to 15 characters for NetBIOS compatibility.
     address:
       tooltip: Cluster networking values cannot be changed after the cluster is created.
@@ -1912,7 +1912,7 @@ cluster:
       servicelb: 'Klipper Service LB'
       traefik: 'Traefik Ingress'
   selectCredential:
-    genericDescription: "{vendor} has no built-in support for this driver.  We've taken a guess, but consult the driver's documentation for the fields required for authentication."
+    genericDescription: "{vendor} has no built-in support for this driver. We've taken a guess, but consult the driver's documentation for the fields required for authentication."
   snapshot:
     successTitle: Snapshot Started
     errorTitle: "Error Snapshotting {name}"
@@ -1930,7 +1930,7 @@ cluster:
       s3: s3
   tabs:
     ace: Authorized Endpoint
-    addons: Add-On Config
+    addons: Add-on Configuration
     advanced: Advanced
     agentEnv: Agent Environment Vars
     basic: Basics
@@ -1954,7 +1954,7 @@ cluster:
     v1: RKE1
     v2: RKE2/K3s
   validation:
-    iamInstanceProfileName: If the Amazon cloud provider is selected the "IAM Instance Profile Name" must be defined for each Machine Pool
+    iamInstanceProfileName: If the Amazon cloud provider is selected the "IAM Instance Profile Name" must be defined for each machine pool
 
 clusterIndexPage:
   hardwareResourceGauge:
@@ -2006,7 +2006,7 @@ configmap:
   tabs:
     data:
       label: Data
-      protip: Use this area for anything that's UTF-8 text data
+      protip: Use this area for anything that contains UTF-8 text data
     binaryData:
       label: Binary Data
 
@@ -2126,7 +2126,7 @@ fleet:
       notReady: Not Ready
       waitApplied: Wait Applied
   gitRepo:
-    createLocalBanner: When deploying a Git Repo to the Local workspace you are unable to target any specific Cluster or Cluster Groups
+    createLocalBanner: When deploying a Git Repo to the local workspace you are unable to target any specific cluster or cluster groups
     tabs:
       resources: Resources
       unready: Non-Ready
@@ -2141,7 +2141,7 @@ fleet:
       label: Paths
       placeholder: e.g. /directory/in/your/repo
       addLabel: Add Path
-      empty: The root of the repo is used by default.  To use one or more different directories, add them here.
+      empty: The root of the repo is used by default. To use one or more different directories, add it here.
     repo:
       label: Repository URL
       placeholder: e.g. https://github.com/rancher/fleet-examples.git or git@github.com:rancher/fleet-examples.git
@@ -2227,7 +2227,7 @@ fleet:
   workspaces:
     tabs:
       restrictions: Allowed Target Namespaces
-    timeout: Workspace creation timeout. It's possible the workspace was created. We suggest checking the workspace page before trying to create another.
+    timeout: Workspace creation timeout. It is possible the workspace was created. We suggest checking the workspace page before trying to create another.
   restrictions:
     addTitle: 'allowedTargetNamespaces'
     addLabel: Add
@@ -2400,10 +2400,10 @@ hpa:
     cpu: CPU
     memory: Memory
   warnings:
-    custom: In order to use custom metrics with HPA, you need to deploy the custom metrics server such as prometheus adapter.
-    external: In order to use external metrics with HPA, you need to deploy the external metrics server such as prometheus adapter.
+    custom: In order to use custom metrics with HPA, you need to deploy the custom metrics server such as Prometheus adapter.
+    external: In order to use external metrics with HPA, you need to deploy the external metrics server such as Prometheus adapter.
     noMetric: In order to use resource metrics with HPA, you need to deploy the metrics server.
-    resource: The selected target reference does not have the correct resource requests on the spec. Without this the HPA metric will have no effect.
+    resource: The selected target reference does not have the correct resource requests on the spec. Without this, the HPA metric will have no effect.
   workloadTab:
     current: Current Replicas
     last: Last Scale Time
@@ -2422,7 +2422,7 @@ import:
     }
 
 ingress:
-  description: Ingresses route incoming traffic from the internet to Services within the cluster based on the hostname and path specified in the request. You can expose multiple Services on the same external IP address and port.
+  description: Ingresses route incoming traffic from the internet to services within the cluster based on the hostname and path specified in the request. You can expose multiple services on the same external IP address and port.
   certificates:
     addCertificate: Add Certificate
     addHost: Add Host
@@ -2449,7 +2449,7 @@ ingress:
     targetService:
       label: Target Service
       doesntExist: The selected service does not exist
-      required: Target Service is required
+      required: Target service is required
     warning: "Warning: Default backend is used globally for the entire cluster."
   ingressClass:
     label: Ingress Class
@@ -2475,7 +2475,7 @@ ingress:
       placeholder: e.g. example.com
     target:
       label: Target Service
-      tooltip: If none of the Services in this dropdown select the Pods that you need to expose, you will need to create a Service that selects those Pods first.
+      tooltip: If none of the services in this drop-down select the pods that you need to expose, you will need to create a service that selects those pods first.
       doesntExist: The selected service does not exist
     title: Rules
   rulesAndCertificates:
@@ -2483,7 +2483,7 @@ ingress:
     defaultCertificate: default
   target:
     default: Default
-  rulesOrBackendSpecified: Either Default Backend or Rules must be specified
+  rulesOrBackendSpecified: Either the default backend or rules must be specified
 
 internalExternalIP:
   none: None
@@ -2495,7 +2495,7 @@ istio:
       description: 'Visualization of services within a service mesh and how they are connected. For Kiali to display data, you need Prometheus installed. If you need a monitoring solution, install <a tabindex="0" href="{link}">{vendor} monitoring</a>.'
     jaeger:
       label: Jaeger
-      description: Monitor and Troubleshoot microservices-based distributed systems.
+      description: Monitor and troubleshoot microservices-based distributed systems.
     disabled: '{app} is not installed'
   cni: Enable CNI
   customOverlayFile:
@@ -2587,7 +2587,7 @@ istio:
         help: Maximum number of HTTP1 /TCP connections to a destination host.
     outlierDetection:
       label: Outlier Detection
-      detail: Configure eviction of unhealthy hosts from the load balancing pool
+      detail: Configure eviction of unhealthy hosts from the load balancing pool.
       baseEjectionTime:
         label: Base Ejection Time
         placeholder: e.g. 30s
@@ -2612,7 +2612,7 @@ istio:
       name:
         label: Name
         placeholder: e.g. v1
-        error: Subset Name is required.
+        error: Subset name is required.
       labels:
         error: Please input at least one label for subset.
     tls:
@@ -2633,11 +2633,11 @@ istio:
       clientCertificate:
         label: Client Certificate
         placeholder: e.g. /etc/certs/myclientcert.pem
-        error: Client Certificate is required.
+        error: Client certificate is required.
       privateKey:
         label: Private Key
         placeholder: e.g. /etc/certs/client_private_key.pem
-        error: Private Key is required.
+        error: Private key is required.
       caCertificates:
         label: CA Certificates
         placeholder: e.g. /etc/certs/rootcacerts.pem
@@ -2667,14 +2667,14 @@ istio:
 
 labels:
   addLabel: Add Label
-  addSetLabel: Add/Set Label
+  addSetLabel: Add or Set Label
   addTag: Add Tag
   addTaint: Add Taint
   addAnnotation: Add Annotation
   labels:
     title: Labels
     description: Key/value pairs that are attached to objects which specify identifying attributes.
-    fleetClusterTooltip: Label changes are made to the Management Cluster and synchronized to the Fleet Cluster
+    fleetClusterTooltip: Label changes are made to the management cluster and synchronized to the Fleet cluster.
     show: Show System Label
     hide: Hide System Label
   annotations:
@@ -2725,7 +2725,7 @@ logging:
     noOutputsBanner: There are no cluster outputs in the selected namespace.
   flow:
     clusterOutputs:
-      doesntExistTooltip: This cluster output doesn't exist
+      doesntExistTooltip: This cluster output does not exist
       label: Cluster Outputs
     matches:
       banner: Configure which container logs will be pulled from
@@ -2759,7 +2759,7 @@ logging:
     filters:
       label: Filters
     outputs:
-      doesntExistTooltip: This output doesn't exist
+      doesntExistTooltip: This output does not exist
       sameNamespaceError: Output must reside in same namespace as the flow.
       label: Outputs
   install:
@@ -2873,7 +2873,7 @@ logging:
     overwriteExistingPath: Overwrite Existing Path
   kinesisStream:
     streamName: Stream Name
-    keyId: Key Id from Secret
+    keyId: Key ID from Secret
     secretKey: Secret Key from Secret
   logdna:
     apiKey: API Key
@@ -2882,7 +2882,7 @@ logging:
   logz:
     url: URL
     port: Port
-    token: Api Token from Secret
+    token: API Token from Secret
     enableCompression: Enable Compression
   newrelic:
     apiKey: API Key from Secret
@@ -2913,7 +2913,7 @@ logging:
       timekeyWait: Timekey Wait
       timekeyUseUTC: Timekey Use UTC
   s3:
-    keyId: Key Id from Secret
+    keyId: Key ID from Secret
     secretKey: Secret Key from Secret
     endpoint: Endpoint
     bucket: Bucket
@@ -2932,7 +2932,7 @@ logging:
       configuration: Configuration
     tips:
       singleProvider: This output is configured with multiple providers. We currently only support a single provider per output. You can view or edit the YAML.
-      multipleProviders: This output is configured with providers we don't support yet. You can view or edit the YAML.
+      multipleProviders: This output is configured with providers we do not support yet. You can view or edit the YAML.
   outputProviders:
     elasticsearch: Elasticsearch
     opensearch: OpenSearch
@@ -3041,7 +3041,7 @@ members:
   clusterPermissions:
     noDescription: User created - no description
     label: Cluster Permissions
-    description: Controls what access users have to the Cluster
+    description: Controls what access users have to the cluster
     createProjects: Create Projects
     manageClusterBackups: Manage Cluster Backups
     manageClusterCatalogs: Manage Cluster Catalogs
@@ -3055,10 +3055,10 @@ members:
     viewNodes: View Nodes
     owner:
       label: Owner
-      description: Owners have full control over the Cluster and all resources inside it.
+      description: Owners have full control over the cluster and all the resources inside it.
     member:
       label: Member
-      description: Members can manage the resources inside the Cluster but not change the Cluster itself.
+      description: Members can manage the resources inside the cluster but not change the cluster itself.
     custom:
       label: Custom
       description: Choose individual roles for this user.
@@ -3078,25 +3078,25 @@ monitoring:
     readOnlyMany: ReadOnlyMany
   aggregateDefaultRoles:
     label: Aggregate to Default Kubernetes Roles
-    tip: 'Adds labels to the ClusterRoles deployed by the Monitoring chart to <a target="_blank" rel="noopener nofollow noreferrer" href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles"> aggregate to the corresponding default k8s admin, edit, and view ClusterRoles.</a>'
+    tip: 'Adds labels to the ClusterRoles deployed by the monitoring chart to <a target="_blank" rel="noopener nofollow noreferrer" href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles"> aggregate to the corresponding default Kubernetes administrator, edit, and view ClusterRoles.</a>'
   alerting:
     config:
-      label: Alert Manager Config
+      label: Alert Manager Configuration
     enable:
       label: Deploy Alertmanager
     secrets:
       additional:
         info: Secrets should be mounted at <pre class='inline-block m-0'>/etc/alertmanager/secrets/</pre>
         label: Additional Secrets
-      existing: Choose an existing config secret
+      existing: Choose an existing configuration secret
       info: |
-        <span class="text-bold">Create default config</span>: A Secret containing your Alertmanager Config will be created in the <pre class='inline-block m-0'>cattle-monitoring-system</pre> namespace on deploying this chart under the name <pre class='inline-block m-0'>alertmanager-rancher-monitoring-alertmanager</pre>. By default, this Secret will never be modified on an uninstall or upgrade of this chart. <br />
-        Once you have deployed this chart, you should edit the Secret via the UI in order to add your custom notification configurations that will be used by Alertmanager to send alerts. <br /> <br />
-        <span class="text-bold">Choose an existing config secret</span>: You must specify a Secret that exists in the <pre class='inline-block m-0'>cattle-monitoring-system</pre> namespace. If the namespace does not exist, you will not be able to select an existing secret.
+        <span class="text-bold">Create default configuration</span>: A Secret containing your Alertmanager configuration will be created in the <pre class='inline-block m-0'>cattle-monitoring-system</pre> namespace on deploying this chart under the name <pre class='inline-block m-0'>alertmanager-rancher-monitoring-alertmanager</pre>. By default, this secret will never be modified on an uninstall or upgrade of this chart. <br />
+        Once you have deployed this chart, edit the secret via the UI in order to add your custom notification configurations that will be used by Alertmanager to send alerts. <br /> <br />
+        <span class="text-bold">Choose an existing configuration secret</span>: You must specify a secret that exists in the <pre class='inline-block m-0'>cattle-monitoring-system</pre> namespace. If the namespace does not exist, you will not be able to select an existing secret.
       label: Alertmanager Secret
-      new: Create default config
+      new: Create default configuration
       radio:
-        label: Config Secret
+        label: Configuration Secret
     validation:
       duplicatedReceiverName: A receiver with the name {name} already exists.
     templates:
@@ -3169,7 +3169,7 @@ monitoring:
       adminApi: Admin API
       evaluation: Evaluation Interval
       ignoreNamespaceSelectors:
-        help: 'Ignoring Namespace Selectors allows Cluster Admins to limit teams from monitoring resources outside of namespaces they have permissions to but can break the functionality of Apps that rely on setting up Monitors that scrape targets across multiple namespaces, such as Istio.'
+        help: 'Ignoring Namespace Selectors allows cluster admins to limit teams from monitoring resources outside of namespaces they have permissions to but can break the functionality of applications that rely on setting up monitors that scrape targets across multiple namespaces, such as Istio.'
         label: Namespace Selectors
         radio:
           enforced: 'Use: Monitors can access resources based on namespaces that match the namespace selector field'
@@ -3189,13 +3189,13 @@ monitoring:
       label: Persistent Storage for Prometheus
       mode: Access Mode
       selector: Selector
-      selectorWarning: 'If you are using a dynamic provisioner (e.g. Longhorn), no Selectors should be specified since a PVC with a non-empty selector can''t have a PV dynamically provisioned for it.'
+      selectorWarning: 'If you are using a dynamic provisioner (e.g. Longhorn), no selectors should be specified since a PVC with a non-empty selector cannot have a PV dynamically provisioned for it.'
       size: Size
       volumeName: Volume Name
     title: Configure Prometheus
     warningInstalled: |
       Warning: Prometheus Operators are currently deployed. Deploying multiple Prometheus Operators onto one cluster is not currently supported. Please remove all other Prometheus Operator deployments from this cluster before trying to install this chart.
-      If you are migrating from an older version of {vendor} with Monitoring enabled, please disable Monitoring on this cluster completely before attempting to install this chart.
+      If you are migrating from an older version of {vendor} with monitoring enabled, please disable monitoring on this cluster completely before attempting to install this chart.
   receiver:
     addReceiver: Add Receiver
     fields:
@@ -3211,16 +3211,16 @@ monitoring:
       keyFilePath:
         label: Key File Path
         placeholder: e.g. ./key-file.pfx
-      secretsBanner: The file paths below must be referenced in <pre class="inline-block m-0 p-0 vertical-middle">alertmanager.alertmanagerSpec.secrets</pre> when deploying the Monitoring chart. For more information see our <a href="{docsBase}/monitoring-alerting/" target="_blank" rel="noopener noreferrer nofollow">documentation</a>.
+      secretsBanner: The file paths below must be referenced in <pre class="inline-block m-0 p-0 vertical-middle">alertmanager.alertmanagerSpec.secrets</pre> when deploying the monitoring chart. For more information see our <a href="{docsBase}/monitoring-alerting/" target="_blank" rel="noopener noreferrer nofollow">documentation</a>.
   projectMonitoring:
     detail:
-      error: "Unable to fetch Dashboard values with status: "
+      error: "Unable to fetch dashboard values with status: "
     list:
-      banner: Project Monitoring Configuration is stored in ProjectHelmChart resources
+      banner: Project monitoring configuration is stored in ProjectHelmChart resources
       empty:
-        message: Project Monitoring has not been configured for any projects
-        canCreate: Get started by clicking Create to add monitoring to a project
-        cannotCreate: Contact the admin to add project monitoring
+        message: Project monitoring has not been configured for any projects
+        canCreate: Get started by clicking create to add monitoring to a project
+        cannotCreate: Contact the administrator to add project monitoring
   route:
     label: Route
     fields:
@@ -3235,9 +3235,9 @@ monitoring:
   alertmanagerConfig:
     description: Routes and receivers for project alerting and cluster alerting are configured within AlertmanagerConfig resources.
     empty: Alerts have not been configured for any accessible namespaces.
-    getStarted: Get started by clicking Create to configure an alert.
+    getStarted: Get started by clicking create to configure an alert.
     receiverTooltip: This route will direct alerts to the selected receiver, which must be defined in the same AlertmanagerConfig.
-    deprecationWarning: The Route and Receiver resources are deprecated. Going forward, routes and receivers should not be managed as separate Kubernetes resources on this page. They should be configured as YAML fields in an AlertmanagerConfig resource.
+    deprecationWarning: The route and receiver resources are deprecated. Going forward, routes and receivers should not be managed as separate Kubernetes resources on this page. They should be configured as YAML fields in an AlertmanagerConfig resource.
     routeInfo: This form supports configuring one route that directs traffic to a receiver. Alerts can be directed to more receiver(s) by configuring child routes in YAML.
     receiverFormNames:
       create: Create Receiver in AlertmanagerConfig
@@ -3272,41 +3272,41 @@ monitoring:
       warning2: <a target="blank" href="{docsBase}/monitoring-alerting/guides/migrating/" target='_blank' rel='noopener nofollow'>Learn more</a> about the migration steps to V2 Monitoring.
       promptDescription: <div class="mt-20 mb-20">You are attempting to uninstall V1 Monitoring. Please ensure you have read the migration steps.</div>
       success1: V1 monitoring successfully uninstalled.
-      success2: Press Next to continue
+      success2: Press next to continue
   tabs:
     alerting: Alerting
     general: General
     grafana: Grafana
     prometheus: Prometheus
     projectMetrics: Project Metrics
-  v1Warning: 'Monitoring is currently deployed from Cluster Manager. If you are migrating from an older version of {vendor} with monitoring enabled, please disable monitoring in Cluster Manager before attempting to install the new {vendor} Monitoring chart in Cluster Explorer.'
+  v1Warning: 'Monitoring is currently deployed from cluster manager. If you are migrating from an older version of {vendor} with monitoring enabled, please disable monitoring in cluster manager before attempting to install the new {vendor} monitoring chart in cluster explorer.'
 
 monitoringReceiver:
   addButton: Add {type}
   custom:
     label: Custom
-    title: Custom Config
-    info: The YAML provided here will be directly appended to your receiver within the Alertmanager Config Secret.
+    title: Custom Configuration
+    info: The YAML provided here will be directly appended to your receiver within the Alertmanager configuration secret.
   email:
     label: Email
-    title: Email Config
+    title: Email Configuration
   opsgenie:
     label: Opsgenie
-    title: Opsgenie Config
+    title: Opsgenie Configuration
   pagerduty:
     label: PagerDuty
-    title: PagerDuty Config
+    title: PagerDuty Configuration
     info: "You can find additional info on creating an Integration Key for PagerDuty <a href='https://www.pagerduty.com/docs/guides/prometheus-integration-guide/' target='_blank' rel='noopener nofollow' class='flex-right'>here</a>."
   slack:
     label: Slack
-    title: Slack Config
+    title: Slack Configuration
     info: "You can find additional info on creating Incoming Webhooks for Slack <a href='https://rancher.slack.com/apps/A0F7XDUAZ-incoming-webhooks' target='_blank' rel='noopener noreferrer nofollow'>here</a> ."
   webhook:
     label: Webhook
-    title: Webhook Config
-    urlTooltip: For some webhooks this a url that points to the service DNS
-    modifyNamespace: If <pre class="inline-block m-0 p-0 vertical-middle">rancher-alerting-drivers</pre> default values were changed, please update the url below in the format http://&lt;new_service_name&gt;.&lt;new_namespace&gt.svc.&lt;port&gt/&lt;path&gt
-    banner: To use MS Teams or SMS you will need to have at least one instance of <pre class="inline-block m-0 p-0 vertical-middle">rancher-alerting-drivers</pre> installed first.
+    title: Webhook Configuration
+    urlTooltip: For some webhooks this a URL that point to the service DNS
+    modifyNamespace: If <pre class="inline-block m-0 p-0 vertical-middle">rancher-alerting-drivers</pre> default values were changed, please update the URL below in the format http://&lt;new_service_name&gt;.&lt;new_namespace&gt.svc.&lt;port&gt/&lt;path&gt
+    banner: To use MS Teams or SMS, you will need to have at least one instance of <pre class="inline-block m-0 p-0 vertical-middle">rancher-alerting-drivers</pre> installed first.
     add:
       selectWebhookType: Select Webhook Type
       generic: Generic
@@ -3341,7 +3341,7 @@ monitoringReceiver:
       label: Enable send resolved alerts
 
 alertmanagerConfigReceiver:
-  secretKeyId: Key Id from Secret
+  secretKeyId: Key ID from Secret
   name: Receiver Name
   addButton: Add Receiver
   receivers: Receivers
@@ -3355,7 +3355,7 @@ monitoringRoute:
     label: Group By
     addGroupByLabel: Labels to Group Alerts By
     groupByTooltip: Add each label as a string in the format key:value. The special label ... will aggregate by all possible labels. If provided, the ... must be the only element in the list.
-  info: This is the top-level Route used by Alertmanager as the default destination for any Alerts that do not match any other Routes. This Route must exist and cannot be deleted.
+  info: This is the top-level route used by Alertmanager as the default destination for any alerts that do not match any other routes. This route must exist and cannot be deleted.
   interval:
     label: Group Interval
   matching:
@@ -3504,7 +3504,7 @@ networkpolicy:
     ruleHint: Incoming traffic is only allowed from the configured sources
     portHint: Incoming traffic is only allowed to connect to the configured ports
   labelsAnnotations:
-    label: Labels & Annotations
+    label: Labels and Annotations
   rules:
     pod: Pod
     namespace: Namespace
@@ -3535,12 +3535,12 @@ networkpolicy:
     namespaceSelector:
       label: Namespace Selector
     namespaceAndPodSelector:
-      label: Namespace/Pod Selector
+      label: Namespace and Pod Selector
   config:
     label: Configuration
   selectors:
     label: Selectors
-    hint: The NetworkPolicy is applied to the selected Pods
+    hint: The NetworkPolicy is applied to the selected pods
     matchingPods:
       matchesSome: |-
         {matched, plural,
@@ -4050,14 +4050,14 @@ plugins:
     subtitle: Catalogs
     imageLoad:
       load: Import Extension Catalog
-      prompt: An Extension Catalog contains extension assets bundled into an image, importing will take the image and host a Helm repository to act as a catalog for custom built Extensions. 
+      prompt: An Extension Catalog contains extension assets bundled into an image, importing will take the image and host a Helm repository to act as a catalog for custom built Extensions.
       fields:
         image:
           label: Catalog Image Reference
           placeholder: "e.g. hub.docker.io/example-org/my-image:latest"
         secrets:
           banner: "If the registry that hosts the Catalog Image requires Pull Secrets, they must be created in the following namespace:<pre>cattle-ui-plugin-system</pre>"
-      banner: This will create an Deployment, Service, and Helm repository to serve the extension charts. 
+      banner: This will create an Deployment, Service, and Helm repository to serve the extension charts.
       imageVersion:
         title: Image Version Not Found
         message: Unable to determine image version from {image}, defaulting to latest


### PR DESCRIPTION
### Summary
Correct spelling mistakes and base UI review performed:

- VM = virtual machine
- addon = add-on
- Remove random capitalisation where not applicable 
- Remove double-spaces after a period
- Expand "config" to "configuration"
- Expand "admin" to "administrator" 
- Expand "docs" to "documentation
- Remove the use of the ampersand
- CDROM/cdrom to "CD-ROM"
- Expand "args" to "argument(s)"

Related Issue #
[Issue #6407](https://github.com/harvester/harvester/issues/6407)
