### PR TITLE
Take image virtual size into account when creating Volumes

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.volume.vue
+++ b/pkg/harvester/edit/harvesterhci.io.volume.vue
@@ -56,6 +56,7 @@ export default {
     const hash = await allHash(_hash);
 
     this.snapshots = hash.snapshots;
+    this.images = hash.images;
 
     const defaultStorage = this.$store.getters[`harvester/all`](STORAGE_CLASS).find( O => O.isDefault);
 
@@ -77,6 +78,7 @@ export default {
       storage,
       imageId,
       snapshots: [],
+      images:    [],
     };
   },
 
@@ -108,10 +110,8 @@ export default {
     },
 
     imageOption() {
-      const choices = this.$store.getters['harvester/all'](HCI.IMAGE);
-
       return sortBy(
-        choices
+        this.images
           .filter(obj => obj.isReady)
           .map((obj) => {
             return {
@@ -249,7 +249,17 @@ export default {
 
       this.$set(this.value, 'spec', spec);
     },
+    updateImage() {
+      if (this.isVMImage && this.imageId) {
+        const imageResource = this.images?.find(image => this.imageId === image.id);
+        const imageSize = Math.max(imageResource?.status?.size, imageResource?.status?.virtualSize);
 
+        if (imageSize) {
+          this.storage = `${ Math.ceil(imageSize / 1024 / 1024 / 1024) }Gi`;
+        }
+      }
+      this.update();
+    },
     generateYaml() {
       const out = saferDump(this.value);
 
@@ -300,7 +310,7 @@ export default {
           required
           :mode="mode"
           class="mb-20"
-          @input="update"
+          @input="updateImage"
         />
 
         <LabeledSelect


### PR DESCRIPTION
This is a followup to https://github.com/harvester/dashboard/pull/1104

When creating new volumes on the Volume screen in Harvester, the default size is empty, i.e. it's not pre-filled with anything at all.  If the source is set to "VM image" we can now take the image virtual size and use that as the default size for the volume. Unlike when creating VMs (which always set the volume to a minimum of 10GiB regardless of virtual size, for consistency with earlier harvester versions), on this screen we just use the virtual size as-is.  If the user wants to make it bigger, they can.

Related issue: https://github.com/harvester/harvester/issues/4905