### PR TITLE
Filter out witness node from VM migration dropdown

### DIFF
--- a/pkg/harvester/dialog/HarvesterMigrationDialog.vue
+++ b/pkg/harvester/dialog/HarvesterMigrationDialog.vue
@@ -72,8 +72,8 @@ export default {
       const nodes = this.$store.getters['harvester/all'](NODE);
 
       return nodes.filter((n) => {
-        // do not allow to migrate to self node
-        return !!this.availableNodes.includes(n.id);
+        // do not allow to migrate to self node and witness node
+        return n.isEtcd !== 'true' && !!this.availableNodes.includes(n.id);
       }).map((n) => {
         let label = n?.metadata?.name;
         const value = n?.metadata?.name;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Filter out witness node when VM migration

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Vicente-Cheng 

Related Issue # [[BUG] The witness node should not be selected as a migration target](https://github.com/harvester/harvester/issues/5338)



### Screenshot/Video
The `harvester-node-1` is witness node. vm is deployed on `harvester-node-0`

<img width="1479" alt="Screenshot 2024-08-27 at 3 00 42 PM" src="https://github.com/user-attachments/assets/c6b6b538-7fc9-435b-9d77-9148d1206f79">

<img width="1474" alt="Screenshot 2024-08-27 at 5 29 55 PM" src="https://github.com/user-attachments/assets/a9aac898-f47b-440a-94a7-f64b93a16a81">
