### PR TITLE
Move reserved memory out from Read More in VM and VM template detail pages

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -348,6 +348,13 @@ export default {
               :mode="mode"
             />
           </div>
+          <div class="col span-6">
+            <Reserved
+              :reserved-memory="reservedMemory"
+              :mode="mode"
+              @updateReserved="updateReserved"
+            />
+          </div>
         </div>
 
         <div class="row mb-20">
@@ -357,13 +364,6 @@ export default {
 
         <div v-if="showAdvanced">
           <div class="row mb-20">
-            <div class="col span-6">
-              <Reserved
-                :reserved-memory="reservedMemory"
-                :mode="mode"
-                @updateReserved="updateReserved"
-              />
-            </div>
             <div class="col span-6">
               <UnitInput
                 v-model="terminationGracePeriodSeconds"

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -633,6 +633,13 @@ export default {
               :mode="mode"
             />
           </div>
+          <div class="col span-6">
+            <Reserved
+              :reserved-memory="reservedMemory"
+              :mode="mode"
+              @updateReserved="updateReserved"
+            />
+          </div>
         </div>
 
         <div class="row mb-20">
@@ -662,13 +669,6 @@ export default {
           </div>
 
           <div class="row mb-20">
-            <div class="col span-6">
-              <Reserved
-                :reserved-memory="reservedMemory"
-                :mode="mode"
-                @updateReserved="updateReserved"
-              />
-            </div>
             <div class="col span-6">
               <UnitInput
                 v-model="terminationGracePeriodSeconds"


### PR DESCRIPTION
### Summary

Move `reserved memory` out from Read More in VM and VM template pages

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @w13915984028 

Related Issue #
https://github.com/harvester/harvester/issues/5768 ([comment](https://github.com/harvester/harvester/issues/5768#issuecomment-2252213149))

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Screenshot/Video
VM detail and edit page
<img width="1294" alt="Screenshot 2024-08-28 at 1 55 28 PM" src="https://github.com/user-attachments/assets/8fc5d6df-8f66-4762-972c-ef01268bb6ce">

VM template detail and edit page
<img width="1292" alt="Screenshot 2024-08-28 at 1 56 51 PM" src="https://github.com/user-attachments/assets/0d9ce67c-16ee-4257-8956-936aea1f403d">

