### PR TITLE
Fix harvester support link does not link to support page when embedded Rancher 2.9

### DIFF
--- a/pkg/harvester/pages/c/_cluster/support/index.vue
+++ b/pkg/harvester/pages/c/_cluster/support/index.vue
@@ -9,7 +9,7 @@ import { SCHEMA } from '@shell/config/types';
 import { HCI } from '../../../../types';
 
 export default {
-  layout: 'home',
+  layout: 'default',
 
   components: {
     BannerGraphic,


### PR DESCRIPTION
### Summary

Starting from Rancher v2.9 , we have [shell/components/templates](https://github.com/rancher/dashboard/tree/v2.9.0/shell/components/templates) defines different page layouts for each page in Rancher.

The router defined in [shell/config/router/router.js](https://github.com/rancher/dashboard/blob/07e1b2edb874777af07dce1cd30eecec1514ed42/shell/config/router/routes.js#L41-L56) missing name in home block. 

------------------------------------------------------------------------------------------------------------------------

To make harvester support page compatible for v2.8.x, v.2.9.0 and v2.9.1, this PR changes harvester support page layout to `default`.

The different is `default layout` has sidebar, while `home layou`t doesn't.

**default layout**
<img width="1493" alt="Screenshot 2024-08-29 at 10 23 10 PM" src="https://github.com/user-attachments/assets/681bec1a-c0e9-471b-8fd3-bc69a01ee2d9">


**home layout**
<img width="1496" alt="Screenshot 2024-08-29 at 10 23 21 PM" src="https://github.com/user-attachments/assets/f54dea2f-28c0-45f3-bcef-ac1901daacaf">

Note. this PR needs backport to v1.4 and v1.3.


#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue # https://github.com/harvester/harvester/issues/6442

### Screenshot/Video
Test on Rancher 2.9

https://github.com/user-attachments/assets/cb3ee3fb-7121-4e11-a051-f3da49d01bce



Test on Rancher 2.8

https://github.com/user-attachments/assets/67e98f03-3d68-420c-a7c6-0b811a0d37cc


