### PR TITLE
Add mergify.yml to automatically open backport PR

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,32 @@
+pull_request_rules:
+- name: Automatically open backport PR to release-harvester-v1.3
+  conditions:
+    - base=master
+    - label="Require backport v1.3"
+  actions:
+    backport:
+      branches:
+        - "release-harvester-v1.3"
+      assignees:
+        - "{{ author }}"
+      labels:
+        - "Backport to v1.3"
+
+- name: Automatically open backport PR to release-harvester-v1.4
+  conditions:
+    - base=master
+  actions:
+    backport:
+      branches:
+        - "release-harvester-v1.4"
+      assignees:
+        - "{{ author }}"
+      labels:
+        - "Backport to v1.4"
+
+- name: Ask to resolve conflict
+  conditions:
+    - conflict
+  actions:
+    comment:
+      message: This pull request is now in conflict. Could you fix it @{{author}}? 🙏


### PR DESCRIPTION
### Summary
For now, any PR merged into `master branch` should backport to `release-harvester-v1.4`, but sometimes we are easily forget to do that.

This PR automates below process 
- automatically open backport PR to release-harvester-v1.4 if any PR merged into master.
- automatically open backport PR to release-harvester-v1.3 if has label `Require backport v1.3` and merged into master.
- ask author to solve conlict

Reference : https://docs.mergify.com/workflow/actions/backport/


#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:
