### PR TITLE
Add additional-guest-memory-overhead-ratio setting

### DIFF
--- a/pkg/harvester/components/settings/additional-guest-memory-overhead-ratio.vue
+++ b/pkg/harvester/components/settings/additional-guest-memory-overhead-ratio.vue
@@ -1,0 +1,39 @@
+<script>
+import CreateEditView from '@shell/mixins/create-edit-view';
+import { LabeledInput } from '@components/Form/LabeledInput';
+
+export default {
+  name: 'AdditionalGuestMemoryOverheadRatio',
+
+  components: { LabeledInput },
+
+  mixins: [CreateEditView],
+
+  data() {
+    return { ratio: this.value.value || this.value.default };
+  },
+
+  methods: {
+    update() {
+      this.$set(this.value, 'value', this.ratio);
+    },
+
+    useDefault() {
+      this.$set(this, 'ratio', this.value.default);
+      this.update();
+    },
+  },
+};
+</script>
+
+<template>
+  <div class="row">
+    <div class="col span-12">
+      <LabeledInput
+        v-model="ratio"
+        :label="t('harvester.setting.ratio')"
+        @input="update"
+      />
+    </div>
+  </div>
+</template>

--- a/pkg/harvester/config/settings.js
+++ b/pkg/harvester/config/settings.js
@@ -33,6 +33,7 @@ export const HCI_SETTING = {
   AUTO_ROTATE_RKE2_CERTS:                 'auto-rotate-rke2-certs',
   KUBECONFIG_DEFAULT_TOKEN_TTL_MINUTES:   'kubeconfig-default-token-ttl-minutes',
   LONGHORN_V2_DATA_ENGINE_ENABLED:        'longhorn-v2-data-engine-enabled',
+  ADDITIONAL_GUEST_MEMORY_OVERHEAD_RATIO: 'additional-guest-memory-overhead-ratio'
 };
 
 export const HCI_ALLOWED_SETTINGS = {
@@ -83,8 +84,9 @@ export const HCI_ALLOWED_SETTINGS = {
   [HCI_SETTING.NTP_SERVERS]:           {
     kind: 'json', from: 'import', canReset: true
   },
-  [HCI_SETTING.KUBECONFIG_DEFAULT_TOKEN_TTL_MINUTES]: {},
-  [HCI_SETTING.LONGHORN_V2_DATA_ENGINE_ENABLED]:      { kind: 'boolean', technicalPreview: true },
+  [HCI_SETTING.KUBECONFIG_DEFAULT_TOKEN_TTL_MINUTES]:   {},
+  [HCI_SETTING.LONGHORN_V2_DATA_ENGINE_ENABLED]:        { kind: 'boolean', technicalPreview: true },
+  [HCI_SETTING.ADDITIONAL_GUEST_MEMORY_OVERHEAD_RATIO]: { kind: 'string', from: 'import' },
 };
 
 export const HCI_SINGLE_CLUSTER_ALLOWED_SETTING = {

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -905,6 +905,7 @@ harvester:
       tip: 'Specify an IP range in the IPv4 CIDR format. <code>Number of IPs Required = Number of Nodes * 4 + Number of Disks * 2 + Number of Images to Download/Upload </code>. For more information about storage network settings, see the <a href="{url}" target="_blank">documentation</a>.'
     vmForceDeletionPolicy:
       period: Period
+    ratio : Ratio
     autoRotateRKE2Certs:
       expiringInHours: Expiring in
     httpProxy:
@@ -1396,6 +1397,7 @@ advancedSettings:
     'harv-auto-rotate-rke2-certs': The certificate rotation mechanism relies on Rancher. Harvester will automatically update certificates generation to trigger rotation.
     'harv-kubeconfig-default-token-ttl-minutes': 'TTL (in minutes) applied on Harvester administration kubeconfig files. Default is 0, which means to never expire.'
     'harv-longhorn-v2-data-engine-enabled': 'Enable the Longhorn V2 data engine. Default is false. <ul><li>Changing this setting will restart RKE2 on all nodes. This will not affect running VM workloads.</li><li>If you see "not enough hugepages-2Mi capacity" errors when enabling this setting, wait a minute for the error to clear. If the error remains, reboot the affected node.</li></ul>'
+    'harv-additional-guest-memory-overhead-ratio': 'The ratio for kubevirt to adjust the VM overhead memory. The value could be zero, empty value or floating number between 1.0 and 10.0, default to 1.5.'
 
 typeLabel:
   kubevirt.io.virtualmachine: |-


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Add additional-guest-memory-overhead-ratio setting
 

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @w13915984028 

Related Issue #
https://github.com/harvester/harvester/issues/5768#issuecomment-2321046677

### Screenshot/Video

[ratio-setting.webm](https://github.com/user-attachments/assets/1d6636a8-8bac-4d86-a55d-954c01d5b9d4)
