### PR TITLE
Fix backup-target setting doesn't set to the latest value

### DIFF
--- a/pkg/harvester/components/SettingList.vue
+++ b/pkg/harvester/components/SettingList.vue
@@ -34,15 +34,7 @@ export default {
   },
 
   data() {
-    const categorySettings = this.settings.filter((s) => {
-      if (this.category !== 'advanced') {
-        return (CATEGORY[this.category] || []).find(item => item === s.id);
-      } else if (this.category === 'advanced') {
-        const allCategory = Object.keys(CATEGORY);
-
-        return !allCategory.some(category => (CATEGORY[category] || []).find(item => item === s.id));
-      }
-    }) || [];
+    const categorySettings = this.filterCategorySettings();
 
     return {
       HCI_SETTING,
@@ -52,7 +44,27 @@ export default {
 
   computed: { ...mapGetters({ t: 'i18n/t' }) },
 
+  watch: {
+    settings: {
+      deep: true,
+      handler() {
+        this.$set(this, 'categorySettings', this.filterCategorySettings());
+      }
+    }
+  },
+
   methods: {
+    filterCategorySettings() {
+      return this.settings.filter((s) => {
+        if (this.category !== 'advanced') {
+          return (CATEGORY[this.category] || []).find(item => item === s.id);
+        } else if (this.category === 'advanced') {
+          const allCategory = Object.keys(CATEGORY);
+
+          return !allCategory.some(category => (CATEGORY[category] || []).find(item => item === s.id));
+        }
+      }) || [];
+    },
     showActionMenu(e, setting) {
       const actionElement = e.srcElement;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Watch settings data to update harvester settings list.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @WebberHuang1118 

Related Issue #
https://github.com/harvester/harvester/issues/4463


### Technical notes summary
harvester backend will auto hide (set to null in API response) below three fields once saved the backup target info. See https://github.com/harvester/harvester/issues/4463#issuecomment-2328016995
- access key id
- secret access key 
- cert 

We just need to refresh the whole settings on UI.

### Screenshot/Video

https://github.com/user-attachments/assets/46bcb657-1aae-4693-a713-cd3b6dda0716

