### PR TITLE
Add cancelAction in VM create page

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -270,6 +270,15 @@ export default {
   },
 
   methods: {
+    cancelAction() {
+      const { fromPage = HCI.VM } = this.$route?.query; // default back to VM list page
+      const cancelOverride = {
+        name:   this.doneRoute,
+        params: { resource: fromPage }
+      };
+
+      this.$router.replace(cancelOverride);
+    },
     saveVM(buttonCb) {
       clear(this.errors);
 
@@ -434,12 +443,14 @@ export default {
     id="vm"
     :done-route="doneRoute"
     :resource="value"
+    :cancelEvent="true"
     :mode="mode"
     :can-yaml="isSingle ? true : false"
     :errors="errors"
     :generate-yaml="generateYaml"
     :apply-hooks="applyHooks"
     @finish="saveVM"
+    @cancel="cancelAction"
   >
     <RadioGroup
       v-if="isCreate"

--- a/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
@@ -48,7 +48,7 @@ export default class HciVmImage extends HarvesterResource {
       {
         action:   'createFromImage',
         enabled:  canCreateVM,
-        icon:     'icon icon-fw icon-spinner',
+        icon:     'icon icon-circle-plus',
         label:    this.t('harvester.action.createVM'),
         disabled: !this.isReady,
       },
@@ -75,7 +75,7 @@ export default class HciVmImage extends HarvesterResource {
     router.push({
       name:   `${ HARVESTER_PRODUCT }-c-cluster-resource-create`,
       params: { resource: HCI.VM },
-      query:  { image: this.id }
+      query:  { image: this.id, fromPage: HCI.IMAGE }
     });
   }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Add cancelAction in VM create page to go back image list page.
- Replace `Create a Viurtal Machine` icon

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
https://github.com/harvester/harvester/issues/6485



### Screenshot/Video
[screen-capture.webm](https://github.com/user-attachments/assets/bd2a4ae9-b80d-4041-910c-a15789045511)

