### PR TITLE
Add volume and image encryption feature

### DIFF
--- a/pkg/harvester/config/harvester-map.js
+++ b/pkg/harvester/config/harvester-map.js
@@ -69,3 +69,12 @@ export const ADD_ONS = {
   RANCHER_MONITORING:               'rancher-monitoring',
   VM_IMPORT_CONTROLLER:             'vm-import-controller',
 };
+
+export const CSI_SECRETS = {
+  CSI_PROVISIONER_SECRET_NAME:       'csi.storage.k8s.io/provisioner-secret-name',
+  CSI_PROVISIONER_SECRET_NAMESPACE:  'csi.storage.k8s.io/provisioner-secret-namespace',
+  CSI_NODE_PUBLISH_SECRET_NAME:      'csi.storage.k8s.io/node-publish-secret-name',
+  CSI_NODE_PUBLISH_SECRET_NAMESPACE: 'csi.storage.k8s.io/node-publish-secret-namespace',
+  CSI_NODE_STAGE_SECRET_NAME:        'csi.storage.k8s.io/node-stage-secret-name',
+  CSI_NODE_STAGE_SECRET_NAMESPACE:   'csi.storage.k8s.io/node-stage-secret-namespace',
+};

--- a/pkg/harvester/config/table-headers.js
+++ b/pkg/harvester/config/table-headers.js
@@ -8,7 +8,6 @@ export const IMAGE_DOWNLOAD_SIZE = {
   labelKey: 'tableHeaders.size',
   value:    'downSize',
   sort:     'status.size',
-  width:    120
 };
 
 export const IMAGE_VIRTUAL_SIZE = {
@@ -16,7 +15,6 @@ export const IMAGE_VIRTUAL_SIZE = {
   labelKey: 'harvester.tableHeaders.virtualSize',
   value:    'virtualSize',
   sort:     'status.virtualSize',
-  width:    120
 };
 
 export const IMAGE_PROGRESS = {

--- a/pkg/harvester/detail/harvesterhci.io.virtualmachineimage/index.vue
+++ b/pkg/harvester/detail/harvesterhci.io.virtualmachineimage/index.vue
@@ -149,9 +149,15 @@ export default {
           <div class="text-label">
             {{ t('harvester.image.encryptionSecret') }}
           </div>
-          <n-link v-if="secretLink" :to="secretLink">
+          <n-link v-if="encryptionSecret && secretLink" :to="secretLink">
             {{ encryptionSecret }}
           </n-link>
+          <span v-else-if="encryptionSecret">
+            {{ encryptionSecret }}
+          </span>
+          <span v-else class="text-muted">
+            &mdash;
+          </span>
         </div>
       </div>
 

--- a/pkg/harvester/detail/harvesterhci.io.virtualmachineimage/index.vue
+++ b/pkg/harvester/detail/harvesterhci.io.virtualmachineimage/index.vue
@@ -7,8 +7,9 @@ import Tabbed from '@shell/components/Tabbed';
 import Tab from '@shell/components/Tabbed/Tab';
 import { findBy } from '@shell/utils/array';
 import { get } from '@shell/utils/object';
-
+import { ucFirst } from '@shell/utils/string';
 import Storage from './Storage';
+import { SECRET } from '@shell/config/types';
 
 export default {
   components: {
@@ -26,8 +27,14 @@ export default {
     },
   },
 
+  async fetch() {
+    const inStore = this.$store.getters['currentProduct'].inStore;
+
+    this.secrets = await this.$store.dispatch(`${ inStore }/findAll`, { type: SECRET });
+  },
+
   data() {
-    return {};
+    return { secrets: [] };
   },
 
   computed: {
@@ -55,6 +62,21 @@ export default {
 
     isUpload() {
       return this.value?.spec?.sourceType === 'upload';
+    },
+
+    encryptionSecret() {
+      if (!this.value.isEncrypted) {
+        return '-';
+      }
+
+      return this.value.encryptionSecret;
+    },
+    secretLink() {
+      return this.secrets.find(sc => sc.id === this.value.encryptionSecret)?.detailLocation;
+    },
+
+    isEncryptedString() {
+      return ucFirst(String(this.value.isEncrypted));
     },
 
     imageName() {
@@ -113,6 +135,23 @@ export default {
       <div class="row">
         <div class="col span-12">
           <LabelValue :name="t('nameNsDescription.description.label')" :value="description" class="mb-20" />
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col span-12">
+          <LabelValue :name="t('harvester.image.isEncryption')" :value="isEncryptedString" class="mb-20" />
+        </div>
+      </div>
+
+      <div v-if="value.isEncrypted" class="row">
+        <div class="col span-12">
+          <div class="text-label">
+            {{ t('harvester.image.encryptionSecret') }}
+          </div>
+          <n-link v-if="secretLink" :to="secretLink">
+            {{ encryptionSecret }}
+          </n-link>
         </div>
       </div>
 

--- a/pkg/harvester/detail/kubevirt.io.virtualmachine/VirtualMachineTabs/VirtualMachineBasics.vue
+++ b/pkg/harvester/detail/kubevirt.io.virtualmachine/VirtualMachineTabs/VirtualMachineBasics.vue
@@ -63,10 +63,7 @@ export default {
 
     imageName() {
       const imageList = this.$store.getters['harvester/all'](HCI.IMAGE) || [];
-
-      const image = imageList.find( (I) => {
-        return this.value.rootImageId === I.id;
-      });
+      const image = imageList.find( I => this.value.rootImageId === I.id);
 
       return image?.spec?.displayName || 'N/A';
     },

--- a/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io.vue
@@ -9,6 +9,7 @@ import { CSI_SECRETS } from '@pkg/harvester/config/harvester-map';
 import { clone } from '@shell/utils/object';
 import { uniq } from '@shell/utils/array';
 
+// UI components for Longhorn storage class parameters
 const DEFAULT_PARAMETERS = [
   'numberOfReplicas',
   'staleReplicaTimeout',
@@ -28,6 +29,8 @@ const {
 } = CSI_SECRETS;
 
 export default {
+  name: 'DriverLonghornIO',
+
   components: {
     KeyValue,
     LabeledSelect,
@@ -57,7 +60,6 @@ export default {
     this.secrets = await this.$store.dispatch(`${ inStore }/findAll`, { type: SECRET });
     this.namespaces = allNamespaces.filter(ns => ns.isSystem === false).map(ns => ns.id); // only show non-system namespaces to user to select
   },
-
   data() {
     if (this.realMode === _CREATE) {
       this.$set(this.value, 'parameters', {
@@ -75,7 +77,16 @@ export default {
       namespaces: [],
     };
   },
-
+  watch: {
+    secretNamespace() {
+      this.$set(this.value, 'parameters', {
+        ...this.value.parameters,
+        [CSI_PROVISIONER_SECRET_NAME]:  '',
+        [CSI_NODE_PUBLISH_SECRET_NAME]: '',
+        [CSI_NODE_STAGE_SECRET_NAME]:   ''
+      });
+    }
+  },
   computed: {
     longhornNodes() {
       const inStore = this.$store.getters['currentProduct'].inStore;
@@ -143,7 +154,11 @@ export default {
       get() {
         const parameters = clone(this.value?.parameters) || {};
 
-        DEFAULT_PARAMETERS.map((key) => {
+        DEFAULT_PARAMETERS.forEach((key) => {
+          delete parameters[key];
+        });
+
+        Object.values(CSI_SECRETS).forEach((key) => {
           delete parameters[key];
         });
 

--- a/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
@@ -8,7 +8,6 @@ import NameNsDescription from '@shell/components/form/NameNsDescription';
 import { RadioGroup } from '@components/Form/Radio';
 import Select from '@shell/components/form/Select';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
-
 import CreateEditView from '@shell/mixins/create-edit-view';
 import { OS } from '../mixins/harvester-vm';
 import { VM_IMAGE_FILE_FORMAT } from '../validators/vm-image';
@@ -18,6 +17,9 @@ import { allHash } from '@shell/utils/promise';
 import { STORAGE_CLASS } from '@shell/config/types';
 import { HCI } from '../types';
 
+const ENCRYPT = 'encrypt';
+const DECRYPT = 'decrypt';
+const CLONE = 'clone';
 const DOWNLOAD = 'download';
 const UPLOAD = 'upload';
 const rawORqcow2 = 'raw_qcow2';
@@ -57,6 +59,8 @@ export default {
     const defaultStorage = this.$store.getters[`${ inStore }/all`](STORAGE_CLASS).find(s => s.isDefault);
 
     this.$set(this, 'storageClassName', this.storageClassName || defaultStorage?.metadata?.name || 'longhorn');
+    this.images = this.$store.getters[`${ inStore }/all`](HCI.IMAGE);
+    this.selectedImage = this.images.find(i => i.name === this.value.name) || null;
   },
 
   data() {
@@ -69,12 +73,14 @@ export default {
     }
 
     return {
-      url:      this.value.spec.url,
-      files:    [],
-      resource: '',
-      headers:  {},
-      fileUrl:  '',
-      file:     '',
+      selectedImage: null,
+      images:        [],
+      url:           this.value.spec.url,
+      files:         [],
+      resource:      '',
+      headers:       {},
+      fileUrl:       '',
+      file:          '',
     };
   },
 
@@ -92,9 +98,16 @@ export default {
     },
 
     showEditAsYaml() {
-      return this.value.spec.sourceType === DOWNLOAD;
+      return this.value.spec.sourceType === DOWNLOAD || this.value.spec.sourceType === CLONE;
     },
-
+    radioGroupOptions() {
+      return [
+        DOWNLOAD,
+        UPLOAD,
+        ENCRYPT,
+        DECRYPT
+      ];
+    },
     storageClassOptions() {
       const inStore = this.$store.getters['currentProduct'].inStore;
       const storages = this.$store.getters[`${ inStore }/all`](STORAGE_CLASS);
@@ -120,9 +133,66 @@ export default {
         this.value.metadata.annotations[HCI_ANNOTATIONS.STORAGE_CLASS] = nue;
       }
     },
+    sourceImageOptions() {
+      let options = [];
+
+      if (this.value.spec.sourceType !== CLONE) {
+        return options;
+      }
+      if (this.value.spec.securityParameters.cryptoOperation === ENCRYPT) {
+        options = this.images.filter(image => !image.isEncrypted);
+      } else {
+        options = this.images.filter(image => image.isEncrypted);
+      }
+
+      return options.map(image => image.spec.displayName);
+    },
+    sourceImageName: {
+      get() {
+        return this.selectedImage?.spec.displayName;
+      },
+      set(imageDisplayName) {
+        this.selectedImage = this.images.find(i => i.spec.displayName === imageDisplayName);
+        // sourceImageName should bring the name of the image
+        this.value.spec.securityParameters.sourceImageName = this.selectedImage?.metadata.name || '';
+      }
+    },
+    sourceType: {
+      get() {
+        if (this.value.spec.sourceType === CLONE) {
+          return this.value.spec.securityParameters.cryptoOperation;
+        } else {
+          return this.value.spec.sourceType;
+        }
+      },
+
+      set(neu) {
+        if (neu === DECRYPT || neu === ENCRYPT) {
+          this.value.spec.sourceType = CLONE;
+          this.$set(this.value.spec, 'securityParameters', {
+            cryptoOperation:      neu,
+            sourceImageName:      '',
+            sourceImageNamespace: this.value.metadata.namespace
+          });
+          this.selectedImage = null;
+        } else {
+          this.$delete(this.value.spec, 'securityParameters');
+          this.value.spec.sourceType = neu;
+        }
+      }
+    }
   },
 
   watch: {
+    'value.metadata.namespace'(neu) {
+      if (this.value.spec.sourceType === CLONE) {
+        this.$set(this.value.spec, 'securityParameters', {
+          cryptoOperation:      this.value.spec.securityParameters.cryptoOperation,
+          sourceImageName:      '',
+          sourceImageNamespace: neu
+        });
+      }
+    },
     'value.spec.url'(neu) {
       const url = neu.trim();
 
@@ -297,15 +367,14 @@ export default {
       >
         <RadioGroup
           v-if="isCreate"
-          v-model="value.spec.sourceType"
+          v-model="sourceType"
           name="model"
-          :options="[
-            'download',
-            'upload',
-          ]"
+          :options="radioGroupOptions"
           :labels="[
             t('harvester.image.sourceType.download'),
             t('harvester.image.sourceType.upload'),
+            t('harvester.image.sourceType.encrypt'),
+            t('harvester.image.sourceType.decrypt'),
           ]"
           :mode="mode"
         />
@@ -331,7 +400,7 @@ export default {
               :tooltip="t('harvester.image.urlTip', {}, true)"
             />
 
-            <div v-else>
+            <div v-else-if="value.spec.sourceType === 'upload'">
               <LabeledInput
                 v-if="isView"
                 v-model="imageName"
@@ -375,6 +444,16 @@ export default {
               :disabled="isEdit"
               label-key="harvester.image.checksum"
               :tooltip="t('harvester.image.checksumTip')"
+            />
+
+            <LabeledSelect
+              v-if="value.spec.sourceType === 'clone'"
+              v-model="sourceImageName"
+              :options="sourceImageOptions"
+              :label="t('harvester.image.sourceImage')"
+              :mode="mode"
+              :disabled="isEdit"
+              class="mb-20"
             />
           </div>
         </div>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/container.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/container.vue
@@ -111,7 +111,7 @@ export default {
 
       <div
         data-testid="input-hec-bus"
-        class="col span-3"
+        class="col span-6"
       >
         <InputOrDisplay
           :name="t('harvester.virtualMachine.volume.bus')"

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -8,12 +8,15 @@ import { PVC } from '@shell/config/types';
 import { HCI } from '../../../../types';
 import { formatSi, parseSi } from '@shell/utils/units';
 import { VOLUME_TYPE, InterfaceOption } from '../../../../config/harvester-map';
+import { _VIEW } from '@shell/config/query-params';
+import LabelValue from '@shell/components/LabelValue';
+import { ucFirst } from '@shell/utils/string';
 
 export default {
   name: 'HarvesterEditVMImage',
 
   components: {
-    UnitInput, LabeledInput, LabeledSelect, InputOrDisplay
+    UnitInput, LabeledInput, LabeledSelect, InputOrDisplay, LabelValue
   },
 
   props: {
@@ -73,6 +76,14 @@ export default {
   },
 
   computed: {
+    encryptionValue() {
+      return ucFirst(String(this.value.isEncrypted));
+    },
+
+    isView() {
+      return this.mode === _VIEW;
+    },
+
     imagesOption() {
       return this.images.filter(c => c.isReady).sort((a, b) => a.creationTimestamp > b.creationTimestamp ? -1 : 1).map( (I) => {
         return {
@@ -270,7 +281,7 @@ export default {
     <div class="row mb-20">
       <div
         data-testid="input-hevi-bus"
-        class="col span-3"
+        class="col span-6"
       >
         <InputOrDisplay
           :name="t('harvester.virtualMachine.volume.bus')"
@@ -285,6 +296,15 @@ export default {
             @input="update"
           />
         </InputOrDisplay>
+      </div>
+      <div
+        v-if="isView"
+        class="col span-6"
+      >
+        <LabelValue
+          :name="t('harvester.virtualMachine.volume.encryption')"
+          :value="encryptionValue"
+        />
       </div>
     </div>
   </div>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
@@ -8,11 +8,14 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { PVC, STORAGE_CLASS } from '@shell/config/types';
 import { formatSi, parseSi } from '@shell/utils/units';
 import { VOLUME_TYPE, InterfaceOption } from '../../../../config/harvester-map';
+import { _VIEW } from '@shell/config/query-params';
+import LabelValue from '@shell/components/LabelValue';
+import { ucFirst } from '@shell/utils/string';
 
 export default {
   name:       'HarvesterEditVolume',
   components: {
-    InputOrDisplay, Loading, LabeledInput, LabeledSelect, UnitInput,
+    InputOrDisplay, Loading, LabeledInput, LabeledSelect, UnitInput, LabelValue
   },
 
   props: {
@@ -58,6 +61,13 @@ export default {
   },
 
   computed: {
+    encryptionValue() {
+      return ucFirst(String(this.value.isEncrypted));
+    },
+
+    isView() {
+      return this.mode === _VIEW;
+    },
     pvcsResource() {
       const allPVCs = this.$store.getters['harvester/all'](PVC) || [];
 
@@ -212,7 +222,7 @@ export default {
     <div class="row mb-20">
       <div
         data-testid="input-hev-bus"
-        class="col span-3"
+        class="col span-6"
       >
         <InputOrDisplay :name="t('harvester.virtualMachine.volume.bus')" :value="value.bus" :mode="mode">
           <LabeledSelect
@@ -224,6 +234,15 @@ export default {
             @input="update"
           />
         </InputOrDisplay>
+      </div>
+      <div
+        v-if="isView"
+        class="col span-6"
+      >
+        <LabelValue
+          :name="t('harvester.virtualMachine.volume.encryption')"
+          :value="encryptionValue"
+        />
       </div>
     </div>
   </div>

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -597,9 +597,9 @@ harvester:
       duplicatedUser: User already exists.
       invalidUser: Invalid Username.
     lockIconTooltip:
-      image: Image encrypted
-      volume: Volume encrypted
-      both: Image encrypted and volume encrypted
+      image: Encrypted Image
+      volume: Encrypted Volume
+      both: Encrypted Image and Encrypted Volume
     input:
       name: Name
       memory: Memory

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -554,8 +554,8 @@ harvester:
       saveVolume: Update Volume
       encryption: Encryption
       lockTooltip:
-        all: All volumes are encrypted
-        partial: Partial volumes are encrypted
+        all: All volumes are encrypted.
+        partial: Some volumes are encrypted.
       title:
         vmImage: Image Volume
         existingVolume: Existing Volume

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -552,6 +552,10 @@ harvester:
       addContainer: Add Container
       setFirst: Set as root volume
       saveVolume: Update Volume
+      encryption: Encryption
+      lockTooltip:
+        all: All volumes are encrypted
+        partial: Partial volumes are encrypted
       title:
         vmImage: Image Volume
         existingVolume: Existing Volume
@@ -596,10 +600,6 @@ harvester:
       userTips: The user to be added must already exist; otherwise, the credentials will not take effect.
       duplicatedUser: User already exists.
       invalidUser: Invalid Username.
-    lockIconTooltip:
-      image: Encrypted Image
-      volume: Encrypted Volume
-      both: Encrypted Image and Encrypted Volume
     input:
       name: Name
       memory: Memory

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -596,6 +596,10 @@ harvester:
       userTips: The user to be added must already exist; otherwise, the credentials will not take effect.
       duplicatedUser: User already exists.
       invalidUser: Invalid Username.
+    lockIconTooltip:
+      image: Image encrypted
+      volume: Volume encrypted
+      both: Image encrypted and volume encrypted
     input:
       name: Name
       memory: Memory

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1069,8 +1069,7 @@ harvester:
     label: Storage
     useDefault: Use the default storage
     volumeEncryption: Volume Encryption
-    secretName: Secret Name
-    secretNamespace: Secret Namespace
+    secret: Secret
     migratable:
       label: Migratable
     numberOfReplicas:

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -166,6 +166,7 @@ harvester:
     reboot: Reboot
     forceStop: Force Stop
   tableHeaders:
+    imageEncryption: Encryption
     size: Size
     virtualSize: Virtual Size
     progress: Progress
@@ -723,6 +724,8 @@ harvester:
       basics: Basics
     url: URL
     size: Size
+    isEncryption: Encryption
+    encryptionSecret: Encryption Secret
     virtualSize: Virtual Size
     urlTip: 'Supports the <code>raw</code> and <code>qcow2</code> image formats which are supported by <a href="https://www.qemu.org/docs/master/system/images.html#disk-image-file-formats" target="_blank">qemu</a>. Bootable ISO images can also be used and are treated like <code>raw</code> images.'
     fileName: File Name
@@ -731,6 +734,11 @@ harvester:
     sourceType:
       download: URL
       upload: File
+      clone: Clone
+      encrypt: Encrypt
+      decrypt: Decrypt
+    sourceImage: Source Image
+    cryptoOperation: Crypto Operation
     warning:
       uploading: |-
         {count, plural,
@@ -1056,6 +1064,9 @@ harvester:
   storage:
     label: Storage
     useDefault: Use the default storage
+    volumeEncryption: Volume Encryption
+    secretName: Secret Name
+    secretNamespace: Secret Namespace
     migratable:
       label: Migratable
     numberOfReplicas:

--- a/pkg/harvester/list/harvesterhci.io.virtualmachineimage.vue
+++ b/pkg/harvester/list/harvesterhci.io.virtualmachineimage.vue
@@ -75,6 +75,22 @@ export default {
       <template #more-header-middle>
         <FilterLabel ref="filterLabel" :rows="rows" @changeRows="changeRows" />
       </template>
+      <template #col:name="{row}">
+        <td>
+          <span>
+            <n-link
+              v-if="row?.detailLocation"
+              :to="row.detailLocation"
+            >
+              {{ row.nameDisplay }}
+              <i v-if="row.isEncrypted" class="icon icon-lock" />
+            </n-link>
+            <span v-else>
+              {{ row.nameDisplay }}
+            </span>
+          </span>
+        </td>
+      </template>
     </ResourceTable>
   </div>
 </template>

--- a/pkg/harvester/list/harvesterhci.io.volume.vue
+++ b/pkg/harvester/list/harvesterhci.io.volume.vue
@@ -158,6 +158,22 @@ export default {
         </n-link>
       </div>
     </template>
+    <template #col:name="{row}">
+      <td>
+        <span>
+          <n-link
+            v-if="row?.detailLocation"
+            :to="row.detailLocation"
+          >
+            {{ row.nameDisplay }}
+            <i v-if="row.isEncrypted" class="icon icon-lock" />
+          </n-link>
+          <span v-else>
+            {{ row.nameDisplay }}
+          </span>
+        </span>
+      </td>
+    </template>
   </ResourceTable>
 </template>
 

--- a/pkg/harvester/list/kubevirt.io.virtualmachine.vue
+++ b/pkg/harvester/list/kubevirt.io.virtualmachine.vue
@@ -172,15 +172,15 @@ export default {
 
   methods: {
     lockIconTooltipMessage(row) {
-      if (row.isVMImageEncrypted && row.isVolumeEncrypted) {
-        return this.t('harvester.virtualMachine.lockIconTooltip.both');
-      } else if (row.isVMImageEncrypted) {
-        return this.t('harvester.virtualMachine.lockIconTooltip.image');
-      } else if (row.isVolumeEncrypted) {
-        return this.t('harvester.virtualMachine.lockIconTooltip.volume');
+      const message = '';
+
+      if (row.encryptedVolumeType === 'all') {
+        return this.t('harvester.virtualMachine.volume.lockTooltip.all');
+      } else if (row.encryptedVolumeType === 'partial') {
+        return this.t('harvester.virtualMachine.volume.lockTooltip.partial');
       }
 
-      return '';
+      return message;
     }
   }
 };
@@ -212,7 +212,12 @@ export default {
             :to="scope.row.detailLocation"
           >
             {{ scope.row.metadata.name }}
-            <i v-if="lockIconTooltipMessage(scope.row)" v-tooltip="lockIconTooltipMessage(scope.row)" class="icon icon-lock" />
+            <i
+              v-if="lockIconTooltipMessage(scope.row)"
+              v-tooltip="lockIconTooltipMessage(scope.row)"
+              class="icon icon-lock"
+              :class="{'green-icon': scope.row.encryptedVolumeType === 'all', 'yellow-icon': scope.row.encryptedVolumeType === 'partial'}"
+            />
           </n-link>
           <span v-else>
             {{ scope.row.metadata.name }}
@@ -231,6 +236,14 @@ export default {
   .vmstate {
     margin-right: 6px;
   }
+}
+
+.green-icon {
+  color: var(--success);
+}
+
+.yellow-icon {
+  color: var(--warning);
 }
 
 .name-console {

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -420,8 +420,10 @@ export default {
         let size = '10Gi';
 
         const imageResource = this.images.find( I => this.imageId === I.id);
+
         const isIsoImage = /iso$/i.test(imageResource?.imageSuffix);
         const imageSize = Math.max(imageResource?.status?.size, imageResource?.status?.virtualSize);
+        const isEncrypted = imageResource?.isEncrypted || false;
 
         if (isIsoImage) {
           bus = 'sata';
@@ -449,6 +451,7 @@ export default {
           storageClassName: '',
           image:            this.imageId,
           volumeMode:       'Block',
+          isEncrypted
         });
       } else {
         out = _disks.map( (DISK, index) => {
@@ -525,7 +528,11 @@ export default {
             minExponent: 3,
           });
 
-          const volumeStatus = this.pvcs.find(P => P.id === `${ this.value.metadata.namespace }/${ volumeName }`)?.relatedPV?.metadata?.annotations?.[HCI_ANNOTATIONS.VOLUME_ERROR];
+          const pvc = this.pvcs.find(P => P.id === `${ this.value.metadata.namespace }/${ volumeName }`);
+
+          const volumeStatus = pvc?.relatedPV?.metadata?.annotations?.[HCI_ANNOTATIONS.VOLUME_ERROR];
+
+          const isEncrypted = pvc?.isEncrypted || false;
 
           return {
             id:         randomStr(5),
@@ -545,7 +552,8 @@ export default {
             hotpluggable,
             volumeStatus,
             dataSource,
-            namespace
+            namespace,
+            isEncrypted
           };
         });
       }

--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -217,7 +217,7 @@ export default class HciPv extends HarvesterResource {
   }
 
   get isEncrypted() {
-    return this.relatedPV?.spec.csi.volumeAttributes.encrypted || false;
+    return Boolean(this.relatedPV?.spec.csi.volumeAttributes.encrypted) || false;
   }
 
   get longhornVolume() {

--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -40,7 +40,7 @@ export default class HciPv extends HarvesterResource {
     return [
       {
         action:  'exportImage',
-        enabled: this.hasAction('export'),
+        enabled: this.hasAction('export') && !this.isEncrypted,
         icon:    'icon icon-copy',
         label:   this.t('harvester.action.exportImage')
       },
@@ -214,6 +214,14 @@ export default class HciPv extends HarvesterResource {
     }
 
     return false;
+  }
+
+  get isEncrypted() {
+    const inStore = this.$rootGetters['currentProduct'].inStore;
+
+    const longhornVolume = this.$rootGetters[`${ inStore }/all`](LONGHORN.VOLUMES).find(v => v.metadata?.name === this.spec?.volumeName);
+
+    return longhornVolume?.spec.encrypted || false;
   }
 
   get longhornVolume() {

--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -217,11 +217,7 @@ export default class HciPv extends HarvesterResource {
   }
 
   get isEncrypted() {
-    const inStore = this.$rootGetters['currentProduct'].inStore;
-
-    const longhornVolume = this.$rootGetters[`${ inStore }/all`](LONGHORN.VOLUMES).find(v => v.metadata?.name === this.spec?.volumeName);
-
-    return longhornVolume?.spec.encrypted || false;
+    return this.relatedPV?.spec.csi.volumeAttributes.encrypted || false;
   }
 
   get longhornVolume() {

--- a/pkg/harvester/models/harvester/secret.js
+++ b/pkg/harvester/models/harvester/secret.js
@@ -2,6 +2,7 @@ import { clone } from '@shell/utils/object';
 import { HCI } from '../../types';
 import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../config/harvester';
 import Secret from '@shell/models/secret';
+import { NAMESPACE } from '@shell/config/types';
 
 export default class HciSecret extends Secret {
   get _detailLocation() {
@@ -50,6 +51,14 @@ export default class HciSecret extends Secret {
 
   get parentLocationOverride() {
     return this.doneOverride;
+  }
+
+  get isSystem() {
+    const inStore = this.$rootGetters['currentProduct'].inStore;
+
+    const systemNs = this.$rootGetters[`${ inStore }/all`](NAMESPACE).filter(ns => ns.isSystem === true).map(ns => ns.metadata.name);
+
+    return systemNs.includes(this.metadata.namespace);
   }
 
   get details() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Add Encrypted, Decrypted radio buttons and source image dropdown In image create page,
- In storage class create page, add volume encryption radio button and  secret namespace, secret name select dropdowns
- Show lock icon if image / volume is encrypted.
- Hide "export image" action if volume is encrypted
- Show encryption and secret in image detail page.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Yu-Jack 

Related Issue #
https://github.com/harvester/harvester/issues/6493


### Screenshot/Video
Create Storage class with Secret
[create_sc.webm](https://github.com/user-attachments/assets/15d1da9d-31c5-4f2d-85a7-baffc7dd8e86)

Encrypted  & decrypt Image 
[image_en:decrypt.webm](https://github.com/user-attachments/assets/f5aed44d-03c4-4ac9-b844-7a9e16ef4450)

Encrypt volume 
[volume_encypt.webm](https://github.com/user-attachments/assets/0c3569e4-06b5-4d68-8b9f-dac796522d96)
