### PR TITLE
Fix: missing allocated translation key

### DIFF
--- a/pkg/harvester/formatters/HarvesterStorageUsed.vue
+++ b/pkg/harvester/formatters/HarvesterStorageUsed.vue
@@ -147,7 +147,7 @@ export default {
       >
         <template #title="{formattedPercentage}">
           <span>
-            {{ t('clusterIndexPage.hardwareResourceGauge.allocated') }}
+            {{ t('harvester.dashboard.hardwareResourceGauge.allocated') }}
           </span>
           <span class="precent-data">
             {{ t('node.detail.glance.consumptionGauge.amount', allocatedAmountTemplateValues) }}

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -308,6 +308,7 @@ harvester:
       cpu: CPU
       memory: Memory
       storage: Storage
+      allocated: Allocated
     sections:
       events:
         label: Events

--- a/pkg/harvester/list/harvesterhci.io.dashboard.vue
+++ b/pkg/harvester/list/harvesterhci.io.dashboard.vue
@@ -662,7 +662,7 @@ export default {
           :name="t('harvester.dashboard.hardwareResourceGauge.storage')"
           :used="storageUsed"
           :reserved="storageAllocated"
-          :reserved-title="t('clusterIndexPage.hardwareResourceGauge.allocated')"
+          :reserved-title="t('harvester.dashboard.hardwareResourceGauge.allocated')"
         />
       </div>
     </template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
We changed storage title from "Reserved" to "Allocated" in https://github.com/harvester/dashboard/pull/1153/files.

Testing on Rancher v2.9.1, the allocated translation key is missing. Because current released rancher shell doesn't have that key

<img width="1496" alt="Screenshot 2024-09-19 at 10 25 57 AM" src="https://github.com/user-attachments/assets/e87cff0e-0d42-458a-897e-9e1183f2d6b6">


The safer way is to use harvester defined translation key


#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
https://github.com/harvester/harvester/issues/6362

### Screenshot/Video
Test on Rancher 2.9.1
<img width="1489" alt="Screenshot 2024-09-19 at 11 06 12 AM" src="https://github.com/user-attachments/assets/40287948-f016-4c5b-9d5e-3460f1204783">

<img width="1496" alt="Screenshot 2024-09-19 at 11 10 11 AM" src="https://github.com/user-attachments/assets/ca3669d1-042c-438c-95d5-2578e29ac0e3">
