### PR TITLE
Pin verdaccio@5.32.2 for check-plugin CI job

### DIFF
--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -25,8 +25,7 @@ if [ $SKIP_SETUP == "false" ]; then
 
   if [ $RET -ne 0 ]; then
     echo "Verdaccio not installed"
-
-    npm install -g verdaccio
+    npm install -g verdaccio@5.32.2
   fi
 
   set +e


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

fix check-plugin job failed : https://github.com/harvester/dashboard/actions/runs/10969497163/job/30462262664?pr=1151

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary

[verdaccio v6.0.0](https://www.npmjs.com/package/verdaccio?activeTab=versions) is released yesterday. But requires node >= 18.

I tried update to node 18 or 20, but causes @achrinza/node-ipc complaining node is too new.

<img width="1496" alt="Screenshot 2024-09-21 at 12 34 13 PM" src="https://github.com/user-attachments/assets/1411afd7-a3e4-4780-bb77-8495f31c7656">

@achrinza/node-ipc needs `v9.2.5` to be able to run on Node 18. See : https://github.com/vuejs/vue-cli/issues/7424#issuecomment-1771133820


