### PR TITLE
Detect Red Hat linux OS Type like Ubuntu and OpenSUSE

### DIFF
--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -51,6 +51,7 @@ export const OS = [{
   value: 'oracle'
 }, {
   label: 'Red Hat',
+  match: ['redhat', 'rhel'],
   value: 'redhat'
 }, {
   label: 'openSUSE',


### PR DESCRIPTION
### Summary
When uploading an image via file or URL, the `OS Type` auto-detection is not working for images named like `rhel-9.4-x86_64-kvm.qcow2`.

Related Issue #
https://github.com/harvester/harvester/issues/6503

### Occurred changes and/or fixed issues
Add the string `rhel` to the matches that are used to identify Red Hat related images.

[Bildschirmaufzeichnung vom 2024-09-23 15-12-54.webm](https://github.com/user-attachments/assets/66031efd-d664-4ee3-ad87-b4af65d9d1bc)

### Test cases
#### Case 1
1. Go `Images` and press `Create`.
2. Set the URL to the `rhel-9.4-x86_64-kvm.qcow2` image, for testing purpose this can ge `https://foo.bar/rhel-9.4-x86_64-kvm.qcow2`.
3. Go to the `Labels` tab and check if the label `harvesterhci.io/os-type` has been set to `Red Hat`.

#### Case 2
1. Go `Images` and press `Create`.
2. Check the `File` checkbox and press `Upload File`. Select a file that is named `rhel-9.4-x86_64-kvm.qcow2`.
3. Go to the `Labels` tab and check if the label `harvesterhci.io/os-type` has been set to `Red Hat`.