### PR TITLE
Fix check-plugins CI job

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1319,7 +1319,7 @@ harvester:
     vGpuDevices: vGPU Devices
     showMore: Show More
     parentSriov: Filter By Parent SR-IOV GPU
-    noPermission: Please contact your system admiistrator to add Harvester add-ons first.
+    noPermission: Please contact your system administrator to add Harvester add-ons first.
     goSetting:
       prefix: The nvidia-driver-toolkit add-on is not enabled, click
       middle: here

--- a/shell/creators/app/app.package.json
+++ b/shell/creators/app/app.package.json
@@ -8,6 +8,6 @@
   "dependencies": {},
   "resolutions": {
     "**/webpack": "4",
-    "@types/node": "^16"
+    "@types/node": "16.11.7"
   }  
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fix https://github.com/harvester/dashboard/actions/runs/11025700963/job/30621227120?pr=1168

I tried using `node 20` in creator package like https://github.com/rancher/dashboard/pull/11808/files did.

But `@nuxt/babel-present-app` is not compatible to node 20.....



<img width="1488" alt="Screenshot 2024-09-25 at 12 08 51 PM" src="https://github.com/user-attachments/assets/1cad0d25-1925-40e9-a4ec-dff7c9a73e8a">

Pin the `@types/node` to v16 instead.


#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

