### PR TITLE
Remove clone action for LVM and LHv2 volume

### DIFF
--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -13,6 +13,7 @@ import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../config/harvester';
 
 import { LONGHORN_DRIVER } from '@shell/models/persistentvolume';
 import { DATA_ENGINE_V2 } from '../../edit/harvesterhci.io.storage/index.vue';
+import { LVM_DRIVER } from './storage.k8s.io.storageclass';
 
 const DEGRADED_ERROR = 'replica scheduling failed';
 
@@ -35,10 +36,15 @@ export default class HciPv extends HarvesterResource {
   get availableActions() {
     let out = super._availableActions;
 
-    const clone = out.find(action => action.action === 'goToClone');
+    // LVM and Longhorn V2 provisioner do not support volume clone feature yet
+    if (this.storageClass.provisioner === LVM_DRIVER || this.storageClass.longhornVersion === DATA_ENGINE_V2) {
+      out = out.filter(action => action.action !== 'goToClone');
+    } else {
+      const clone = out.find(action => action.action === 'goToClone');
 
-    if (clone) {
-      clone.action = 'goToCloneVolume';
+      if (clone) {
+        clone.action = 'goToCloneVolume';
+      }
     }
 
     if (this.storageClass.provisioner !== LONGHORN_DRIVER || this.storageClass.longhornVersion !== DATA_ENGINE_V2) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
As title ,remove clone action for LVM or LHv2 volume and VM attached with LVM or LHv2 volumes

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @tserong 

Related Issue #
https://github.com/harvester/harvester/issues/6762



### Screenshot/Video
<img width="1494" alt="Screenshot 2024-10-14 at 4 04 47 PM" src="https://github.com/user-attachments/assets/7841a80a-3ad8-42b0-ae2c-c581445cb277">
<img width="1496" alt="Screenshot 2024-10-14 at 4 15 47 PM" src="https://github.com/user-attachments/assets/2b8bd9b9-755c-4285-b865-c9249c912ab4">
