### PR TITLE
Rename some VM shorthands to Virtual Machine

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -195,7 +195,7 @@ harvester:
     retain: Retain
     scheduleType: Type
     maxFailure: Max Failure
-    sourceVm: Source VM
+    sourceVm: Source Virtual Machine
     vmSchedule: Virtual Machine Schedule
     hostIp: Host IP
     vm:

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -118,7 +118,7 @@ harvester:
       name: 'New Volume Name'
       success: 'New Volume { name } restored successfully.'
     vmSnapshot:
-      title: Take VM Snapshot
+      title: Take Virtual Machine Snapshot
       name: Name
       success: 'Take virtual machine Snapshot { name } successfully.'
     restart:
@@ -144,7 +144,7 @@ harvester:
     encryptImage: Encrypt Image
     decryptImage: Decrypt Image
     ejectCDROM: Eject CD-ROM
-    editVMQuota: Edit VM Quota
+    editVMQuota: Edit Virtual Machine Quota
     launchFormTemplate: Launch instance from template
     modifyTemplate: Modify template (Create new version)
     setDefaultVersion: Set default version

--- a/pkg/harvester/list/harvesterhci.io.virtualmachinebackup.vue
+++ b/pkg/harvester/list/harvesterhci.io.virtualmachinebackup.vue
@@ -118,7 +118,7 @@ export default {
         NAMESPACE,
         {
           name:      'targetVM',
-          labelKey:  'tableHeaders.targetVm',
+          labelKey:  'harvester.tableHeaders.targetVm',
           value:     'attachVM',
           align:     'left',
           formatter: 'AttachVMWithName'

--- a/pkg/harvester/list/harvesterhci.io.vmsnapshot.vue
+++ b/pkg/harvester/list/harvesterhci.io.vmsnapshot.vue
@@ -64,7 +64,7 @@ export default {
         NAMESPACE,
         {
           name:      'targetVM',
-          labelKey:  'tableHeaders.targetVm',
+          labelKey:  'harvester.tableHeaders.targetVm',
           value:     'attachVM',
           align:     'left',
           sort:      'attachVM',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Rename 
- Edit VM quota -> Edit Virtual Machine Quota
- Take VM Snapshot -> Take Virtual Machine Snapshot
- Target VM -> Target Virtual Machine
- Source VM -> Source Virtual Machine

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
https://github.com/harvester/harvester/issues/6407#issuecomment-2401421959


### Screenshot/Video
<img width="1479" alt="Screenshot 2024-10-14 at 4 29 01 PM" src="https://github.com/user-attachments/assets/9dbc0b04-abe7-43b4-962b-24831bd8bc2b">

<img width="1496" alt="Screenshot 2024-10-14 at 4 35 21 PM" src="https://github.com/user-attachments/assets/d3edb99e-5830-40e5-9c48-07c101465368">

