### PR TITLE
feat: extend degraded errors

### DIFF
--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -14,7 +14,7 @@ import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../config/harvester';
 import { LONGHORN_DRIVER } from '@shell/models/persistentvolume';
 import { DATA_ENGINE_V2 } from '../../edit/harvesterhci.io.storage/index.vue';
 
-const DEGRADED_ERROR = 'replica scheduling failed';
+const DEGRADED_ERRORS = ['replica scheduling failed', 'precheck new replica failed'];
 
 export default class HciPv extends HarvesterResource {
   applyDefaults(_, realMode) {
@@ -116,7 +116,7 @@ export default class HciPv extends HarvesterResource {
 
   get stateDisplay() {
     const volumeError = this.relatedPV?.metadata?.annotations?.[HCI_ANNOTATIONS.VOLUME_ERROR];
-    const degradedVolume = volumeError === DEGRADED_ERROR;
+    const degradedVolume = DEGRADED_ERRORS.includes(volumeError);
     const status = this?.status?.phase === 'Bound' && !volumeError && this.isLonghornVolumeReady ? 'Ready' : 'Not Ready';
 
     const conditions = this?.status?.conditions || [];
@@ -135,7 +135,7 @@ export default class HciPv extends HarvesterResource {
   // state is similar with stateDisplay, the reason we keep this property is the status of In-use should not be displayed on vm detail page
   get state() {
     const volumeError = this.relatedPV?.metadata?.annotations?.[HCI_ANNOTATIONS.VOLUME_ERROR];
-    const degradedVolume = volumeError === DEGRADED_ERROR;
+    const degradedVolume = DEGRADED_ERRORS.includes(volumeError);
     let status = this?.status?.phase === 'Bound' && !volumeError ? 'Ready' : 'Not Ready';
 
     const conditions = this?.status?.conditions || [];


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

> [!CAUTION]
> Should test again after Harvester bumps LH to v1.7.2-rc1.


#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue https://github.com/harvester/harvester/issues/6669

### Occurred changes and/or fixed issues
[LH added new message about failed replica](https://github.com/longhorn/longhorn-manager/pull/2918). The new `precheck new replica failed` should be treated as a DEGRADED status.

### Technical notes summary
Extend DEGRADED error list.


### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
![Screenshot 2024-10-15 at 11 05 10 AM](https://github.com/user-attachments/assets/db88b0da-542e-4b5d-9a0f-07db3b610887)
