### PR TITLE
Disable volume size input when isLonghornV2 and edit mode

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.volume.vue
+++ b/pkg/harvester/edit/harvesterhci.io.volume.vue
@@ -8,7 +8,6 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import { Banner } from '@components/Banner';
-
 import { allHash } from '@shell/utils/promise';
 import { get } from '@shell/utils/object';
 import { HCI, VOLUME_SNAPSHOT } from '../types';
@@ -16,7 +15,7 @@ import { STORAGE_CLASS, LONGHORN, PV } from '@shell/config/types';
 import { sortBy } from '@shell/utils/sort';
 import { saferDump } from '@shell/utils/create-yaml';
 import { InterfaceOption, VOLUME_DATA_SOURCE_KIND } from '../config/harvester-map';
-import { _CREATE } from '@shell/config/query-params';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
 import { STATE, NAME, AGE, NAMESPACE } from '@shell/config/table-headers';
@@ -93,6 +92,10 @@ export default {
   computed: {
     isBlank() {
       return this.source === 'blank';
+    },
+
+    isEdit() {
+      return this.mode === _EDIT;
     },
 
     isVMImage() {
@@ -346,13 +349,13 @@ export default {
           :output-modifier="true"
           :increment="1024"
           :mode="mode"
-          :disabled="isLonghornV2"
+          :disabled="isLonghornV2 && isEdit"
           required
           class="mb-20"
           @input="update"
         />
 
-        <Banner v-if="isLonghornV2" color="warning">
+        <Banner v-if="isLonghornV2 && isEdit" color="warning">
           <span>{{ t('harvester.volume.longhorn.disableResize') }}</span>
         </Banner>
       </Tab>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Disable volume size input when isLonghornV2 and edit mode

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @tserong 

Related Issue #
https://github.com/harvester/harvester/issues/6791



### Screenshot/Video
Create mode 
<img width="1495" alt="Screenshot 2024-10-16 at 2 13 08 PM" src="https://github.com/user-attachments/assets/7fb3aea2-0589-41f3-a34d-c38463558813">


Edit mode

<img width="1496" alt="Screenshot 2024-10-16 at 2 12 59 PM" src="https://github.com/user-attachments/assets/d4795551-cd2c-4630-9b76-371000f2d665">
