### PR TITLE
Root disk volume accessMode should be RWX

### DIFF
--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -25,7 +25,6 @@ import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations
 import impl, { QGA_JSON, USB_TABLET } from './impl';
 import { uniq } from '@shell/utils/array';
 import { parseVolumeClaimTemplates } from '../../utils/vm';
-import { LONGHORN_VERSION_V1, LONGHORN_VERSION_V2 } from '@shell/models/persistentvolume';
 
 const LONGHORN_V2_DATA_ENGINE = 'longhorn-system/v2-data-engine';
 
@@ -258,12 +257,6 @@ export default {
       }
     },
 
-    longhornSystemVersion() {
-      const v2DataEngine = this.$store.getters[`${ this.inStore }/byId`](LONGHORN.SETTINGS, LONGHORN_V2_DATA_ENGINE) || {};
-
-      return v2DataEngine.value === 'true' ? LONGHORN_VERSION_V2 : LONGHORN_VERSION_V1;
-    },
-
     customVolumeMode() {
       return this.storageClassSetting.volumeMode || 'Block';
     },
@@ -455,7 +448,7 @@ export default {
           id:               randomStr(5),
           source:           SOURCE_TYPE.IMAGE,
           name:             'disk-0',
-          accessMode:       this.longhornSystemVersion === LONGHORN_VERSION_V2 ? 'ReadWriteOnce' : 'ReadWriteMany',
+          accessMode:       'ReadWriteMany', // root disk only support LHv1 volume, should be RWX
           bus,
           volumeName:       '',
           size,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Current root image only supports LHv1 volume, accessMode should be RWX.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @tserong 

Related Issue #
https://github.com/harvester/harvester/issues/6793

### Screenshot/Video
<img width="1496" alt="Screenshot 2024-10-16 at 3 44 43 PM" src="https://github.com/user-attachments/assets/f5da6f50-cc8a-4da0-8c36-96bba317d325">
<img width="1496" alt="Screenshot 2024-10-16 at 3 44 58 PM" src="https://github.com/user-attachments/assets/1d9154fc-3fe3-45c4-b86e-70770b6c15f5">
