### PR TITLE
Port ResourceCancelModal change into harvester shell

### DIFF
--- a/shell/components/ResourceCancelModal.vue
+++ b/shell/components/ResourceCancelModal.vue
@@ -47,7 +47,7 @@ export default {
 <template>
   <app-modal
     v-if="showModal"
-    class="confirm-modal"
+    customClass="confirm-modal"
     name="cancel-modal"
     :width="440"
     height="auto"
@@ -96,32 +96,27 @@ export default {
     margin: 0 10px;
   }
 
-  .v--modal-box {
-    background-color: var(--default);
-    box-shadow: none;
-    min-height: 200px;
-    .body {
-      min-height: 75px;
-      padding: 10px 0 0 15px;
-      p {
-        margin-top: 10px;
-      }
+  .body {
+    min-height: 75px;
+    padding: 10px 0 0 15px;
+    p {
+      margin-top: 10px;
     }
-    .header {
-      background-color: var(--error);
-      padding: 15px 0 0 15px;
-      height: 50px;
+  }
+  .header {
+    background-color: var(--error);
+    padding: 15px 0 0 15px;
+    height: 50px;
 
-      h4 {
-        color: white;
-      }
+    h4 {
+      color: white;
     }
-    .footer {
-      border-top: 1px solid var(--border);
-      text-align: center;
-      padding: 10px 0 0 15px;
-      height: 60px;
-    }
+  }
+  .footer {
+    border-top: 1px solid var(--border);
+    text-align: center;
+    padding: 10px 0 0 15px;
+    height: 60px;
   }
 }
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Previous app modal porting missing ResourceCancelModal.vue change.

This PR ports `ResourceCancelModal` change into harvester shell.

ResourceCancelModal.vue in  Rancher/dashboard: https://github.com/rancher/dashboard/blob/aa015eda0474def6c302a7c92796731e5432b9a9/shell/components/ResourceCancelModal.vue#L55-L125

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
https://github.com/harvester/harvester/issues/6814

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

Before fix
<img width="1486" alt="Screenshot 2024-10-17 at 11 04 52 AM" src="https://github.com/user-attachments/assets/1a782185-251a-4fde-8415-feaccbdaa554">

After fix
<img width="1494" alt="Screenshot 2024-10-17 at 11 20 42 AM" src="https://github.com/user-attachments/assets/826b02a7-fcea-487f-9c43-9ff3782569ac">
