### PR TITLE
Change upgrade error banner to red color

### DIFF
--- a/pkg/harvester/components/HarvesterUpgrade.vue
+++ b/pkg/harvester/components/HarvesterUpgrade.vue
@@ -188,7 +188,7 @@ export default {
             <Checkbox v-model="readyReleaseNote" class="check" type="checkbox" label-key="harvester.upgradePage.checkReady" />
           </div>
 
-          <Banner v-if="errors.length" color="warning">
+          <Banner v-if="errors.length" color="error">
             {{ errors }}
           </Banner>
         </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Change upgrade error banner to error color.

Since this is one line change, I feel it's safe to backport to v1.4 release branch.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @w13915984028 

Related Issue #
https://github.com/harvester/harvester/issues/6847

### Screenshot/Video
After fix
<img width="1487" alt="Screenshot 2024-10-23 at 10 07 17 AM" src="https://github.com/user-attachments/assets/b950b45c-373c-4cdb-bbbc-290437df8dbe">
