### PR TITLE
fix delete VM modal cannot be dismiss

### DIFF
--- a/pkg/harvester/promptRemove/kubevirt.io.virtualmachine.vue
+++ b/pkg/harvester/promptRemove/kubevirt.io.virtualmachine.vue
@@ -84,7 +84,7 @@ export default {
   methods: {
     resourceNames,
     remove() {
-      const parentComponent = this.$parent.$parent.$parent;
+      const parentComponent = this.$parent.$parent.$parent.$parent;
 
       let goTo;
 

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -247,8 +247,6 @@ export default {
         // where the custom dialog needs to delete additional resources - it handles those and retrurns false to get us
         // to delete the main resource
         if (handled === undefined || handled) {
-          this.close();
-
           return;
         }
       }


### PR DESCRIPTION
### Summary
I added `this.close()` in harvester legacy shell in previous AppModal porting PR to solve VM deletion modal can not dismiss issue.

```
#PromptRemove.vue

if (handled === undefined || handled) {
          this.close();
          return;
  }
```

But it's not solve the issue in root cause. 

The root cause is commented in https://github.com/harvester/harvester/issues/6878#issuecomment-2451327542


#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
https://github.com/harvester/harvester/issues/6840



### Screenshot/Video

On standalone harvester

https://github.com/user-attachments/assets/b0961fa5-7393-4976-91c8-ca390bd0346f



Rancher 2.9.2

https://github.com/user-attachments/assets/8d3c09e9-d19a-44e9-b429-4565dd465176


