### PR TITLE
Align CPU pinning checkbox position in cloud template

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -356,19 +356,6 @@ export default {
             />
           </div>
         </div>
-
-        <div class="row mb-20">
-          <div class="col span-6">
-            <Checkbox
-              v-model="cpuPinning"
-              class="check"
-              type="checkbox"
-              label-key="harvester.virtualMachine.cpuPinning.label"
-              :mode="mode"
-            />
-          </div>
-        </div>
-
         <div class="row mb-20">
           <a v-if="showAdvanced" v-t="'harvester.generic.showMore'" role="button" @click="toggleAdvanced" />
           <a v-else v-t="'harvester.generic.showMore'" role="button" @click="toggleAdvanced" />
@@ -399,6 +386,14 @@ export default {
         />
 
         <div class="spacer"></div>
+        <Checkbox
+          v-model="cpuPinning"
+          class="check"
+          type="checkbox"
+          tooltip-key="harvester.virtualMachine.cpuPinning.tooltip"
+          label-key="harvester.virtualMachine.cpuPinning.label"
+          :mode="mode"
+        />
         <Checkbox
           v-model="installUSBTablet"
           class="check"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Align CPU pinning checkbox position in cloud template. This is just simple checkbox position change. 
I think it's fine to backport to release-v1.4.


#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @brandboat 

Related Issue #
https://github.com/harvester/harvester/issues/6879

### Occurred changes and/or fixed issues
https://github.com/harvester/harvester/issues/6879

### Screenshot/Video

Before
<img width="1496" alt="Screenshot 2024-10-26 at 12 26 04 PM" src="https://github.com/user-attachments/assets/4627de81-9a6f-4c9b-9490-0bdb6d544450">


After
<img width="1496" alt="Screenshot 2024-11-04 at 3 39 45 PM" src="https://github.com/user-attachments/assets/9c5b2207-fe79-46ca-beba-725bf61eb06a">
