### PR TITLE
[WORKAROUND] fix create namespace page broken on rancher 2.8.x

### DIFF
--- a/shell/models/steve-schema.ts
+++ b/shell/models/steve-schema.ts
@@ -99,6 +99,11 @@ export default class SteveSchema extends Schema {
    */
   get resourceFields(): ResourceFields {
     if (this.requiresResourceFields) {
+      // workaround to avoid throw below error on Rancher 2.8.x
+      if (!this.schemaDefinitionsIds && !this.schemaDefinition) {
+        return {};
+      }
+
       if (!this.schemaDefinitionsIds) {
         throw new Error(`Cannot find resourceFields for Schema ${ this.id } (schemaDefinitions have not been fetched) `);
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

`shell/models/steve-schema.ts` was added in https://github.com/harvester/dashboard/pull/1208 which was not existed on Rancher v2.8 shell.

This PR add workaround if condition to avoid fall into below two throw new Error.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
https://github.com/harvester/harvester/issues/6953

### Screenshot/Video
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/f622a970-2c92-45a3-b58e-71cfebd1b14b">