### PR TITLE
Get provisioner and engine version from Volume

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.storage/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/index.vue
@@ -20,11 +20,9 @@ import { allHash } from '@shell/utils/promise';
 import { clone } from '@shell/utils/object';
 import { LONGHORN_DRIVER } from '@shell/models/persistentvolume';
 import { LVM_DRIVER } from '../../models/harvester/storage.k8s.io.storageclass';
+import { DATA_ENGINE_V1, DATA_ENGINE_V2 } from '../../models/harvester/persistentvolumeclaim';
 
 const LONGHORN_V2_DATA_ENGINE = 'longhorn-system/v2-data-engine';
-
-export const DATA_ENGINE_V1 = 'v1';
-export const DATA_ENGINE_V2 = 'v2';
 
 export const LVM_TOPOLOGY_LABEL = 'topology.lvm.csi/node';
 

--- a/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v1.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v1.vue
@@ -8,7 +8,7 @@ import { _CREATE, _VIEW } from '@shell/config/query-params';
 import { CSI_SECRETS } from '@pkg/harvester/config/harvester-map';
 import { clone } from '@shell/utils/object';
 import { uniq } from '@shell/utils/array';
-import { DATA_ENGINE_V1 } from '../index.vue';
+import { DATA_ENGINE_V1 } from '../../../models/harvester/persistentvolumeclaim';
 
 // UI components for Longhorn storage class parameters
 const DEFAULT_PARAMETERS = [

--- a/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v2.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v2.vue
@@ -8,7 +8,7 @@ import { _CREATE, _VIEW } from '@shell/config/query-params';
 import { CSI_SECRETS } from '@pkg/harvester/config/harvester-map';
 import { clone } from '@shell/utils/object';
 import { uniq } from '@shell/utils/array';
-import { DATA_ENGINE_V2 } from '../index.vue';
+import { DATA_ENGINE_V2 } from '../../../models/harvester/persistentvolumeclaim';
 
 // UI components for Longhorn storage class parameters
 const DEFAULT_PARAMETERS = [

--- a/pkg/harvester/edit/harvesterhci.io.volume.vue
+++ b/pkg/harvester/edit/harvesterhci.io.volume.vue
@@ -20,7 +20,7 @@ import CreateEditView from '@shell/mixins/create-edit-view';
 import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
 import { STATE, NAME, AGE, NAMESPACE } from '@shell/config/table-headers';
 import { LVM_DRIVER } from '../models/harvester/storage.k8s.io.storageclass';
-import { DATA_ENGINE_V2 } from './harvesterhci.io.storage/index.vue';
+import { DATA_ENGINE_V2 } from '../models/harvester/persistentvolumeclaim';
 
 export default {
   name: 'HarvesterVolume',
@@ -224,24 +224,28 @@ export default {
 
     rebuildStatus() {
       return this.value.longhornEngine?.status?.rebuildStatus;
-    },
-
-    isLonghornV2() {
-      return this.value.storageClass?.isLonghornV2;
     }
   },
 
   methods: {
+    getAccessMode() {
+      const storageClassName = this.value.spec.storageClassName;
+      const storageClass = this.storageClasses.find(sc => sc.name === storageClassName);
+
+      let readWriteOnce = this.value.isLvm || this.value.isLonghornV2;
+
+      if (storageClass) {
+        readWriteOnce = storageClass.provisioner === LVM_DRIVER || storageClass.parameters?.dataEngine === DATA_ENGINE_V2;
+      }
+
+      return readWriteOnce ? ['ReadWriteOnce'] : ['ReadWriteMany'];
+    },
     willSave() {
       this.update();
     },
     update() {
       let imageAnnotations = '';
       let storageClassName = this.value.spec.storageClassName;
-
-      const storageClass = this.storageClasses.find(sc => sc.name === storageClassName);
-      const storageClassProvisioner = storageClass?.provisioner;
-      const storageClassDataEngine = storageClass?.parameters?.dataEngine;
 
       if (this.isVMImage && this.imageId) {
         const images = this.$store.getters['harvester/all'](HCI.IMAGE);
@@ -259,7 +263,7 @@ export default {
         ...this.value.spec,
         resources:   { requests: { storage: this.storage } },
         storageClassName,
-        accessModes: storageClassProvisioner === LVM_DRIVER || storageClassDataEngine === DATA_ENGINE_V2 ? ['ReadWriteOnce'] : ['ReadWriteMany'],
+        accessModes: this.getAccessMode(),
       };
 
       this.value.setAnnotations(imageAnnotations);
@@ -349,13 +353,13 @@ export default {
           :output-modifier="true"
           :increment="1024"
           :mode="mode"
-          :disabled="isLonghornV2 && isEdit"
+          :disabled="value?.isLonghornV2 && isEdit"
           required
           class="mb-20"
           @input="update"
         />
 
-        <Banner v-if="isLonghornV2 && isEdit" color="warning">
+        <Banner v-if="value?.isLonghornV2 && isEdit" color="warning">
           <span>{{ t('harvester.volume.longhorn.disableResize') }}</span>
         </Banner>
       </Tab>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/index.vue
@@ -258,7 +258,7 @@ export default {
     },
 
     isLonghornV2(volume) {
-      return volume?.pvc?.storageClass?.isLonghornV2;
+      return volume?.pvc?.isLonghornV2 || volume?.pvc?.storageClass?.isLonghornV2;
     }
   },
 };

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -115,7 +115,7 @@ export default {
     },
 
     isLonghornV2() {
-      return this.value.pvc?.storageClass?.isLonghornV2;
+      return this.value.pvc?.isLonghornV2 || this.value.pvc?.storageClass?.isLonghornV2;
     }
   },
 

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
@@ -11,7 +11,7 @@ import { _VIEW } from '@shell/config/query-params';
 import LabelValue from '@shell/components/LabelValue';
 import { ucFirst } from '@shell/utils/string';
 import { LVM_DRIVER } from '../../../../models/harvester/storage.k8s.io.storageclass';
-import { DATA_ENGINE_V2 } from '../../../../edit/harvesterhci.io.storage/index.vue';
+import { DATA_ENGINE_V2 } from '../../../../models/harvester/persistentvolumeclaim';
 
 export default {
   name:       'HarvesterEditVolume',
@@ -102,7 +102,7 @@ export default {
     },
 
     isLonghornV2() {
-      return this.value.pvc?.storageClass?.isLonghornV2;
+      return this.value.pvc?.isLonghornV2 || this.value.pvc?.storageClass?.isLonghornV2;
     }
   },
 
@@ -110,11 +110,7 @@ export default {
     'value.storageClassName': {
       immediate: true,
       handler(neu) {
-        const storageClass = this.storageClasses.find(sc => sc.name === neu);
-        const provisioner = storageClass?.provisioner;
-        const engine = storageClass?.parameters?.dataEngine;
-
-        this.value.accessMode = provisioner === LVM_DRIVER || engine === DATA_ENGINE_V2 ? 'ReadWriteOnce' : 'ReadWriteMany';
+        this.value.accessMode = this.getAccessMode(neu);
       }
     },
 
@@ -146,6 +142,18 @@ export default {
   },
 
   methods: {
+    getAccessMode(storageClassName) {
+      const storageClass = this.storageClasses.find(sc => sc.name === storageClassName);
+
+      let readWriteOnce = this.value.pvc?.isLvm || this.value.pvc?.isLonghornV2;
+
+      if (storageClass) {
+        readWriteOnce = storageClass.provisioner === LVM_DRIVER || storageClass.parameters?.dataEngine === DATA_ENGINE_V2;
+      }
+
+      return readWriteOnce ? 'ReadWriteOnce' : 'ReadWriteMany';
+    },
+
     update() {
       this.$emit('update');
     },

--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -10,11 +10,13 @@ import { get, clone } from '@shell/utils/object';
 import { colorForState } from '@shell/plugins/dashboard-store/resource-class';
 import HarvesterResource from '../harvester';
 import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../config/harvester';
-
+import { LVM_DRIVER } from './storage.k8s.io.storageclass';
 import { LONGHORN_DRIVER } from '@shell/models/persistentvolume';
-import { DATA_ENGINE_V2 } from '../../edit/harvesterhci.io.storage/index.vue';
 
 const DEGRADED_ERRORS = ['replica scheduling failed', 'precheck new replica failed'];
+
+export const DATA_ENGINE_V1 = 'v1';
+export const DATA_ENGINE_V2 = 'v2';
 
 export default class HciPv extends HarvesterResource {
   applyDefaults(_, realMode) {
@@ -36,7 +38,7 @@ export default class HciPv extends HarvesterResource {
     let out = super._availableActions;
 
     // Longhorn V2 provisioner do not support volume clone feature yet
-    if (this.storageClass.longhornVersion === DATA_ENGINE_V2) {
+    if (this.isLonghornV2) {
       out = out.filter(action => action.action !== 'goToClone');
     } else {
       const clone = out.find(action => action.action === 'goToClone');
@@ -46,7 +48,7 @@ export default class HciPv extends HarvesterResource {
       }
     }
 
-    if (this.storageClass.provisioner !== LONGHORN_DRIVER || this.storageClass.longhornVersion !== DATA_ENGINE_V2) {
+    if (!this.isLonghorn || !this.isLonghornV2) {
       out = [
         {
           action:  'exportImage',
@@ -303,6 +305,26 @@ export default class HciPv extends HarvesterResource {
 
   get relatedPV() {
     return this.$rootGetters['harvester/all'](PV).find(pv => pv.metadata?.name === this.spec?.volumeName);
+  }
+
+  get volumeProvider() {
+    return this.relatedPV?.spec.csi?.driver;
+  }
+
+  get dataEngine() {
+    return this.relatedPV?.spec.csi?.volumeAttributes?.dataEngine;
+  }
+
+  get isLvm() {
+    return this.volumeProvider === LVM_DRIVER;
+  }
+
+  get isLonghorn() {
+    return this.volumeProvider === LONGHORN_DRIVER;
+  }
+
+  get isLonghornV2() {
+    return this.dataEngine === DATA_ENGINE_V2;
   }
 
   get resourceExternalLink() {

--- a/pkg/harvester/models/harvester/storage.k8s.io.storageclass.js
+++ b/pkg/harvester/models/harvester/storage.k8s.io.storageclass.js
@@ -3,7 +3,7 @@ import { HCI } from '../../types';
 import StorageClass from '@shell/models/storage.k8s.io.storageclass';
 import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../config/harvester';
 import { LONGHORN_DRIVER } from '@shell/models/persistentvolume';
-import { DATA_ENGINE_V1, DATA_ENGINE_V2 } from '../../edit/harvesterhci.io.storage/index.vue';
+import { DATA_ENGINE_V1, DATA_ENGINE_V2 } from '../../models/harvester/persistentvolumeclaim';
 
 export const LVM_DRIVER = 'lvm.driver.harvesterhci.io';
 

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -15,7 +15,6 @@ import { matchesSomeRegex } from '@shell/utils/string';
 import { LABELS_TO_IGNORE_REGEX } from '@shell/config/labels-annotations';
 import { BACKUP_TYPE } from '../config/types';
 import { parseVolumeClaimTemplates } from '@pkg/utils/vm';
-import { LVM_DRIVER } from './harvester/storage.k8s.io.storageclass';
 
 export const OFF = 'Off';
 
@@ -610,11 +609,11 @@ export default class VirtVm extends HarvesterResource {
   }
 
   get lvmVolumes() {
-    return this.volumes.filter(volume => volume.storageClass.provisioner === LVM_DRIVER);
+    return this.volumes.filter(volume => volume?.isLvm);
   }
 
   get longhornV2Volumes() {
-    return this.volumes.filter(volume => volume.storageClass.isLonghornV2);
+    return this.volumes.filter(volume => volume?.isLonghornV2);
   }
 
   get encryptedVolumeType() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

The UI is currently using the Volume -> Storage Class object to get the `provisioner` and the `engine version` (for Longhorn).
The Storage Class can be null, if deleted by the uses.

We want to get those fields from PersistentVolume `spec` when the storageClass is null

- provisioner: `spec.csi.driver`
- dataEngine: `spec.csi.volumeAttributes.dataEngine`

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue https://github.com/harvester/harvester/issues/6927
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->