### PR TITLE
fix storage class page broken if get unknown provisioner

### DIFF
--- a/pkg/harvester/models/harvester/storage.k8s.io.storageclass.js
+++ b/pkg/harvester/models/harvester/storage.k8s.io.storageclass.js
@@ -55,7 +55,7 @@ export default class HciStorageClass extends StorageClass {
       key = `harvester.storage.storageClass.lvm.label`;
     }
 
-    return this.$rootGetters['i18n/t'](key);
+    return key ? this.$rootGetters['i18n/t'](key) : null;
   }
 
   get isLonghornV2() {


### PR DESCRIPTION
### Summary
`freenas-iscsi-csi` provisoner is unknown which is not Longhorn v1, Longhornv2 or LVM.

We can show empty string for unknown provisoner 

<img width="1493" alt="Screenshot 2024-11-08 at 11 19 34 AM" src="https://github.com/user-attachments/assets/b66d5c9a-627b-4a8b-8883-b79b2b544344">

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
https://github.com/harvester/harvester/issues/6970

### Screenshot/Video

<img width="1493" alt="Screenshot 2024-11-08 at 11 25 19 AM" src="https://github.com/user-attachments/assets/cbef11f1-c3b0-4263-91e1-8bc377a01fa9">
