### PR TITLE
Show provisioner in provisioner colume instead of empty string

### DIFF
--- a/pkg/harvester/models/harvester/storage.k8s.io.storageclass.js
+++ b/pkg/harvester/models/harvester/storage.k8s.io.storageclass.js
@@ -55,7 +55,7 @@ export default class HciStorageClass extends StorageClass {
       key = `harvester.storage.storageClass.lvm.label`;
     }
 
-    return key ? this.$rootGetters['i18n/t'](key) : null;
+    return key ? this.$rootGetters['i18n/t'](key) : this.provisioner;
   }
 
   get isLonghornV2() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Based on https://github.com/harvester/dashboard/pull/1227#issuecomment-2467324125, show provisioner instead of null



#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
https://github.com/harvester/dashboard/pull/1227

