### PR TITLE
Automatically set volume size for ISO images

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -141,14 +141,12 @@ export default {
     onImageChange() {
       const imageResource = this.$store.getters['harvester/all'](HCI.IMAGE)?.find( I => this.value.image === I.id);
 
-      if (this.idx === 0) {
-        if (/iso$/i.test(imageResource?.imageSuffix)) {
-          this.$set(this.value, 'type', 'cd-rom');
-          this.$set(this.value, 'bus', 'sata');
-        } else {
-          this.$set(this.value, 'type', 'disk');
-          this.$set(this.value, 'bus', 'virtio');
-        }
+      if (/iso$/i.test(imageResource?.imageSuffix)) {
+        this.$set(this.value, 'type', 'cd-rom');
+        this.$set(this.value, 'bus', 'sata');
+      } else {
+        this.$set(this.value, 'type', 'disk');
+        this.$set(this.value, 'bus', 'virtio');
       }
 
       this.update();

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -140,10 +140,17 @@ export default {
 
     onImageChange() {
       const imageResource = this.$store.getters['harvester/all'](HCI.IMAGE)?.find( I => this.value.image === I.id);
+      const isIsoImage = /iso$/i.test(imageResource?.imageSuffix);
+      const imageSize = imageResource?.status?.size;
 
-      if (/iso$/i.test(imageResource?.imageSuffix)) {
+      if (isIsoImage) {
         this.$set(this.value, 'type', 'cd-rom');
         this.$set(this.value, 'bus', 'sata');
+        if (imageSize) {
+          const imageSizeGiB = Math.ceil(imageSize / 1024 / 1024 / 1024);
+
+          this.$set(this.value, 'size', `${ imageSizeGiB }Gi`);
+        }
       } else {
         this.$set(this.value, 'type', 'disk');
         this.$set(this.value, 'bus', 'virtio');

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -401,15 +401,25 @@ export default {
       let out = [];
 
       if (_disks.length === 0) {
+        let bus = 'virtio';
+        let type = HARD_DISK;
+
+        const imageResource = this.images.find( I => this.imageId === I.id);
+
+        if (/iso$/i.test(imageResource?.imageSuffix)) {
+          bus = 'sata';
+          type = CD_ROM;
+        }
+
         out.push({
           id:               randomStr(5),
           source:           SOURCE_TYPE.IMAGE,
           name:             'disk-0',
           accessMode:       'ReadWriteMany',
-          bus:              'virtio',
+          bus,
           volumeName:       '',
           size:             '10Gi',
-          type:             HARD_DISK,
+          type,
           storageClassName: '',
           image:            this.imageId,
           volumeMode:       'Block',

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -403,12 +403,20 @@ export default {
       if (_disks.length === 0) {
         let bus = 'virtio';
         let type = HARD_DISK;
+        let size = '10Gi';
 
         const imageResource = this.images.find( I => this.imageId === I.id);
+        const isIsoImage = /iso$/i.test(imageResource?.imageSuffix);
+        const imageSize = imageResource?.status?.size;
 
-        if (/iso$/i.test(imageResource?.imageSuffix)) {
+        if (isIsoImage) {
           bus = 'sata';
           type = CD_ROM;
+          if (imageSize) {
+            const imageSizeGiB = Math.ceil(imageSize / 1024 / 1024 / 1024);
+
+            size = `${ imageSizeGiB }Gi`;
+          }
         }
 
         out.push({
@@ -418,7 +426,7 @@ export default {
           accessMode:       'ReadWriteMany',
           bus,
           volumeName:       '',
-          size:             '10Gi',
+          size,
           type,
           storageClassName: '',
           image:            this.imageId,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
https://github.com/harvester/harvester/issues/6554

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

Prior to this, the default size for volumes attached to VMs was 10GiB, regardless of the size of the underlying image.  This is silly for ISO images, for which we can determine the size automatically.  The volume size will be set to the size of the ISO image, rounded up to the next whole number of GiB.

This PR also incidentally includes the fix for https://github.com/harvester/harvester/issues/5142 to set the bus type correctly for CD-ROMs.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This PR is based on larger work done for Harvester v1.4 (for details of that see https://github.com/harvester/dashboard/pull/976)

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->