### PR TITLE
fix API token data not refresh issue

### DIFF
--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -746,6 +746,11 @@ export const actions = {
       const isRancherInHarvester = (rancherManagerSupport?.value || rancherManagerSupport?.default) === 'true';
 
       commit('isRancherInHarvester', isRancherInHarvester);
+      // standalone harvester cluster needs to subscribe rancher socket to get latest token data update
+      if (getters['isSingleProduct']) {
+        console.log('Detect standalone harvester, subscribe rancher socket'); // eslint-disable-line no-console
+        await dispatch('rancher/subscribe');
+      }
     }
 
     const pl = res.settings?.find(x => x.id === 'ui-pl')?.value;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Fix API token data not refresh in standalone harvester.

Standalone harvester doesn't have websocket connect to `/v3/token`. While rancher dashboard have dispatch [rancher/subscribe](https://github.com/rancher/dashboard/blob/master/shell/store/index.js#L799).

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Yu-Jack 

Related Issue #
https://github.com/harvester/harvester/issues/6841

Backend PR : https://github.com/harvester/harvester/pull/7076

Note. this PR needs to open in rancher/dashboard to fix the same issue on harvester-ui-extension.


### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

<img width="1495" alt="Screenshot 2024-12-03 at 1 21 45 PM" src="https://github.com/user-attachments/assets/f7b50ca9-7cc8-4b6a-8ba9-32ab5ea60a38">






https://github.com/user-attachments/assets/b6c5701f-b255-4434-8a11-7febef33a668

