### PR TITLE
Add Require backport v1.4 label in mergify.yaml

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,6 +15,7 @@ pull_request_rules:
 - name: Automatically open backport PR to release-harvester-v1.4
   conditions:
     - base=master
+    - label="Require backport v1.4"
   actions:
     backport:
       branches:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

v1.4.0 release is out. 
Any PR attached with `Require backport v1.4`  label will auto open backport PR via mergify.

