### PR TITLE
fix: separate used/allocated units

### DIFF
--- a/pkg/harvester/formatters/HarvesterStorageUsed.vue
+++ b/pkg/harvester/formatters/HarvesterStorageUsed.vue
@@ -72,17 +72,23 @@ export default {
       return stats;
     },
 
-    units() {
+    allocatedUnits() {
+      const exponent = exponentNeeded(this.storageStats.total, 1024);
+
+      return `${ UNITS[exponent] }iB`;
+    },
+
+    usedUnits() {
       const exponent = exponentNeeded(this.storageStats.maximum, 1024);
 
       return `${ UNITS[exponent] }iB`;
     },
 
-    used() {
+    formatUsed() {
       let out = this.formatter(this.storageStats.used);
 
       if (!Number.parseFloat(out) > 0) {
-        out = this.formatter(this.storageStats.used, { canRoundToZero: false });
+        out = this.formatter(this.storageStats.used, { canRoundToZero: true });
       }
 
       return out;
@@ -92,7 +98,7 @@ export default {
       let out = this.formatter(this.storageStats.scheduled);
 
       if (!Number.parseFloat(out) > 0) {
-        out = this.formatter(this.storageStats.scheduled, { canRoundToZero: false });
+        out = this.formatter(this.storageStats.scheduled, { canRoundToZero: true });
       }
 
       return out;
@@ -100,9 +106,9 @@ export default {
 
     usedAmountTemplateValues() {
       return {
-        used:  this.used,
+        used:  this.formatUsed,
         total: this.formatter(this.storageStats.maximum),
-        unit:  this.units,
+        unit:  this.usedUnits,
       };
     },
 
@@ -110,7 +116,7 @@ export default {
       return {
         used:  this.formatAllocated,
         total: this.formatter(this.storageStats.total),
-        unit:  this.units,
+        unit:  this.allocatedUnits,
       };
     },
   },
@@ -141,7 +147,7 @@ export default {
       <ConsumptionGauge
         :capacity="storageStats.total"
         :used="storageStats.scheduled"
-        :units="units"
+        :units="allocatedUnits"
         :number-formatter="formatter"
         :resource-name="resourceName"
       >
@@ -161,7 +167,7 @@ export default {
     <ConsumptionGauge
       :capacity="storageStats.maximum"
       :used="storageStats.used"
-      :units="units"
+      :units="usedUnits"
       :number-formatter="formatter"
       :resource-name="showAllocated ? '' : resourceName"
       :class="{


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Allocated and used in storage column might in different units. (GiB/ TiB)

Separate the allocated / used unit calculation to avoid using the same unit.


#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @starbops 

Related Issue #
https://github.com/harvester/harvester/issues/7081

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
Before  (the used value is 32 MB / 1.62TiB)

<img width="1496" alt="Screenshot 2024-12-09 at 1 54 09 PM" src="https://github.com/user-attachments/assets/65025a15-2e8d-4826-832b-71d0cb4123d5">

After
<img width="1491" alt="Screenshot 2024-12-09 at 2 07 47 PM" src="https://github.com/user-attachments/assets/3b4826cf-2531-45d2-8db7-1307ad800a8a">

