### PR TITLE
fix: keep parent sriov filter result if pcidevices status change

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
@@ -93,7 +93,11 @@ export default {
     devices: {
       handler(v) {
         this.rows = v;
-        this.filterRows = this.rows;
+        if (this.parentSriov) {
+          this.filterRows = this.rows.filter(row => row.labels[this.parentSriovLabel] === this.parentSriov);
+        } else {
+          this.filterRows = this.rows;
+        }
       },
       immediate: true,
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
fix: keep parent sriov filter result if pcidevices status change


#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
https://github.com/harvester/harvester/issues/6660


### Screenshot/Video
Fixed Recording

https://github.com/user-attachments/assets/f394f8f9-3380-45f1-963a-b05376ce6dec


