### PR TITLE
fix: port AppModal component to harvester source code

### DIFF
--- a/pkg/harvester/components/AppModal.vue
+++ b/pkg/harvester/components/AppModal.vue
@@ -1,0 +1,170 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'AppModal',
+
+  // emits: ['close'],
+
+  inheritAttrs: false,
+  props:        {
+    /**
+     * If set to false, it will not be possible to close modal by clicking on
+     * the background or by pressing Esc key.
+     */
+    clickToClose: {
+      type:    Boolean,
+      default: true,
+    },
+    /**
+     * Width in pixels or percents (50, "50px", "50%").
+     *
+     * Supported string values are <number>% and <number>px
+     */
+    width: {
+      type:    [Number, String],
+      default: 600,
+      validator(value) {
+        if (typeof value === 'number') {
+          return value > 0;
+        }
+
+        if (typeof value === 'string') {
+          return /^(0*(?:[1-9][0-9]*|0)\.?\d*)+(px|%)$/.test(value);
+        }
+
+        return false;
+      }
+    },
+    /**
+     * List of class that will be applied to the modal window
+     */
+    customClass: {
+      type:    String,
+      default: '',
+    },
+    /**
+     * Style that will be applied to the modal window
+     */
+    styles: {
+      type:    String,
+      default: '',
+    },
+    /**
+     * Name of the modal
+     */
+    name: {
+      type:    String,
+      default: '',
+    }
+  },
+  computed: {
+    modalWidth(): string {
+      const uom = typeof (this.width) === 'number' ? 'px' : '';
+
+      return `${ this.width }${ uom }`;
+    },
+    stylesPropToObj(): object {
+      return this.styles.split(';')
+        .map(line => line.trim().split(':'))
+        .reduce((lines, [key, val]) => {
+          return {
+            ...lines,
+            [key]: val
+          };
+        }, { });
+    },
+    modalStyles(): object {
+      return {
+        width: this.modalWidth,
+        ...this.stylesPropToObj,
+      };
+    }
+  },
+  mounted() {
+    document.addEventListener('keydown', this.handleEscapeKey);
+  },
+  beforeDestroy() {
+    document.removeEventListener('keydown', this.handleEscapeKey);
+  },
+  methods: {
+    handleClickOutside(event: MouseEvent) {
+      if (
+        this.clickToClose &&
+        this.$refs.modalRef &&
+        !(this.$refs.modalRef as HTMLElement).contains(event.target as Node)
+      ) {
+        this.$emit('close');
+      }
+    },
+    handleEscapeKey(event: KeyboardEvent) {
+      if (this.clickToClose && event.key === 'Escape') {
+        this.$emit('close');
+      }
+    }
+  }
+});
+</script>
+
+<template>
+  <mounting-portal
+    mountTo="#__layout"
+    name="source"
+    append
+  >
+    <transition
+      name="modal-fade"
+      appear
+    >
+      <div
+        class="modal-overlay"
+        :data-modal="name"
+        @click="handleClickOutside"
+      >
+        <div
+          v-bind="$attrs"
+          ref="modalRef"
+          :class="customClass"
+          class="modal-container"
+          :style="modalStyles"
+          @click.stop
+        >
+          <slot><!--Empty content--></slot>
+        </div>
+      </div>
+    </transition>
+  </mounting-portal>
+</template>
+
+<style lang="scss">
+  .modal-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: var(--overlay-bg);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 20;
+
+    .modal-container {
+      background-color: var(--modal-bg);
+      border-radius: var(--border-radius);
+      max-height: 95vh;
+      overflow: auto;
+      border: 2px solid var(--modal-border);
+    }
+  }
+
+  .modal-fade-enter-active,
+  .modal-fade-leave-active {
+    transition: opacity 200ms;
+  }
+
+  .modal-fade-enter,
+  .modal-fade-leave-to {
+    opacity: 0;
+  }
+</style>

--- a/pkg/harvester/dialog/HarvesterSupportBundle.vue
+++ b/pkg/harvester/dialog/HarvesterSupportBundle.vue
@@ -6,7 +6,7 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import AsyncButton from '@shell/components/AsyncButton';
 import GraphCircle from '@shell/components/graph/Circle';
 import { Banner } from '@components/Banner';
-import AppModal from '@shell/components/AppModal';
+import AppModal from '@pkg/harvester/components/AppModal';
 
 export default {
   name: 'SupportBundle',

--- a/pkg/harvester/dialog/RestartVMDialog.vue
+++ b/pkg/harvester/dialog/RestartVMDialog.vue
@@ -1,7 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import AsyncButton from '@shell/components/AsyncButton';
-import AppModal from '@shell/components/AppModal';
+import AppModal from '@pkg/harvester/components/AppModal';
 import { Card } from '@components/Card';
 import { Banner } from '@components/Banner';
 import { exceptionToErrorsArray } from '@shell/utils/error';


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Previous [PR](https://github.com/harvester/dashboard/pull/1163) port AppModal component from Rancher/shell to harvester shell. But the appModal was introduced after Rancher 2.9+ which causes it doesn't exist on Rancher 2.8.

This PR port AppModal component to harvester source code.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
https://github.com/harvester/harvester/issues/7147


### Screenshot/Video

```
1. Import harvester into Rancher 2.8 or 2.9
2. Pull this PR locally and run `yarn build-pkg harvester && yarn serve-pkgs`
3. Change 
   - ui-plugin-index setting to http://127.0.0.1:4500/harvester-1.4.0/harvester-1.4.0.umd.min.js
   - ui-source to external
4. Refresh
```
Test on Rancher 2.9


https://github.com/user-attachments/assets/413e425a-ddd7-47de-afac-89039d951789


Test on Rancher 2.8

https://github.com/user-attachments/assets/0c88408b-5fbf-417b-9649-36cf88f3d569

