### PR TITLE
fix: vGPU number not correct

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVGpuDevices/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVGpuDevices/index.vue
@@ -46,10 +46,13 @@ export default {
       this[key] = res[key];
     }
 
-    uniq([
+    const vGpus = this.vm.isOff ? [
       ...(this.value?.domain?.devices?.gpus || []).map(({ name }) => name),
+    ] : [
       ...Object.values(this.vm?.provisionedVGpus).reduce((acc, gpus) => [...acc, ...gpus], [])
-    ]).forEach((name) => {
+    ];
+
+    uniq(vGpus).forEach((name) => {
       if (this.enabledDevices.find(device => device?.metadata?.name === name)) {
         this.selectedDevices.push(name);
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Consume `domain?.devices?.gpus` when VM is off, while consume `harvesterhci.io/deviceAllocationDetails` when VM is running 
#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Yu-Jack 

Related Issue #
https://github.com/harvester/harvester/issues/7003



### Screenshot/Video
<img width="1487" alt="image" src="https://github.com/user-attachments/assets/2e7864c2-c67b-462b-a5c2-94b260f3845e" />
