### PR TITLE
fix: isEncrypted breaks volume page

### DIFF
--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -229,7 +229,7 @@ export default class HciPv extends HarvesterResource {
   }
 
   get isEncrypted() {
-    return this.relatedPV?.spec.csi.volumeAttributes.encrypted === 'true';
+    return this.relatedPV?.spec?.csi?.volumeAttributes?.encrypted === 'true';
   }
 
   get longhornVolume() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

fix: isEncrypted() breaks the volume page.


#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Vicente-Cheng 

Related Issue #
https://github.com/harvester/harvester/issues/7150

### Reproduce step

kubectl apply  -f fake-pv.yaml

```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: fake-pv
spec:
  accessModes:
  - ReadWriteMany
  capacity:
    storage: 10Gi
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: fake-pvc
    namespace: default
  volumeMode: Block
  local:
    path: /tmp/foo
  nodeAffinity:
    required:
      nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/hostname
            operator: In
            values:
            - fake-node-name
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: fake-pvc
spec:
  accessModes:
  - ReadWriteMany
  resources:
    requests:
      storage: 10Gi
  volumeMode: Block
  volumeName: fake-pv
```
### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

Before fix
<img width="1496" alt="Screenshot 2025-01-09 at 3 07 04 PM" src="https://github.com/user-attachments/assets/b11d9f03-2e4a-41ab-908e-40d52e96eaa0" />

After fix

<img width="1492" alt="image" src="https://github.com/user-attachments/assets/58f19dbe-21eb-4cbf-9bc5-42f70b09e706" />
