### PR TITLE
fix: missing vnc reconnecting label

### DIFF
--- a/pkg/harvester/components/novnc/NovncConsole.vue
+++ b/pkg/harvester/components/novnc/NovncConsole.vue
@@ -17,7 +17,7 @@
       <main class="main-layout">
         <div class="text-center">
           <h2 class="text-secondary mt-20">
-            {{ t('vncConsole.reconnecting.message') }}：{{ retryTimes }} of {{ maximumRetryTimes }}
+            {{ t('harvester.virtualMachine.vncConsole.reconnecting.message') }}：{{ retryTimes }} of {{ maximumRetryTimes }}
           </h2>
         </div>
       </main>

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -534,6 +534,9 @@ harvester:
     console:
       novnc: Open in WebVNC
       serial: Open in Serial Console
+    vncConsole:
+      reconnecting:
+        message: Web VNC console reconnection attempt
     promptRemove:
       title: 'Select the volume you want to delete:'
       deleteAll: Delete All
@@ -850,14 +853,14 @@ harvester:
       doc: Read the <a href="{url}" target="_blank">documentation</a> before starting the upgrade process. Ensure that you complete procedures that are relevant to your environment and the version you are upgrading to.
       tip: Unmet system requirements and incorrectly performed procedures may cause complete upgrade failure and other issues that require manual workarounds.
       moreNotes: For more details about the release notes, please visit -
-     
+
   schedule:
     label: Virtual Machine Schedules
     createTitle: Create Schedule
     createButtonText: Create Schedule
     scheduleType: Virtual Machine Schedule Type
     cron: Cron Schedule
-    detail: 
+    detail:
       namespace: Namespace
       sourceVM: Source Virtual Machine
     tabs:
@@ -867,12 +870,12 @@ harvester:
     message:
       noSetting:
         suffix: before creating a backup schedule
-    retain: 
+    retain:
       label: Retain
       count: Count
-      tooltip: Number of up-to-date VM backups to retain. Maximum to 250, minimum to 2. 
+      tooltip: Number of up-to-date VM backups to retain. Maximum to 250, minimum to 2.
     maxFailure:
-      label: Max Failure 
+      label: Max Failure
       count: Count
       tooltip: Max number of consecutive failed backups that could be tolerated. If reach this threshold, Harvester controller will suspend the schedule job. This value should less than retain count
     virtualMachine:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
`vncConsole.reconnecting.message` label is missing

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] [UI] Missing vnc reconnecting label #7182](https://github.com/harvester/harvester/issues/7182)

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
The label is missing from the shell/assets/translations/en-us.yaml in Rancher version 2.9 and lower.
Ref: https://github.com/rancher/dashboard/blob/release-2.9/shell/assets/translations/en-us.yaml#L7757-L7759.
Add translation key to `pkg/harvester/l10n/en-us.yaml` to fix the issue.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Add translation key to `pkg/harvester/l10n/en-us.yaml` to fix the issue.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Go to Rancher
2. Go to Virtualization Management -> Harvester cluster -> Virtual Machines
3. Click on Console button
4. Check the reconnecting label

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1512" alt="Screenshot 2025-01-07 at 1 54 59 PM" src="https://github.com/user-attachments/assets/074e5264-6d7c-4cca-aa31-1641280305fc" />
