### PR TITLE
feat: cluster output select dropdown should show meaningful sentence if no options available

### DIFF
--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -111,7 +111,7 @@ export default {
 
     // update placeholder text to inform user they can add their own opts when none are found
     showTagPrompts() {
-      return !this.options.length && this.$attrs.taggable;
+      return !this.options.length && this.$attrs.taggable && this.isSearchable;
     }
   },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Display the corresponding message if no matching options are found.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue [#7305](https://github.com/harvester/harvester/issues/7305)

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Add condition `this.isSearchable` to function `showTagPrompts`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Go to Rancher
Go to Virtualization Management -> Harvester cluster -> Virtual Machines
Click on Console button

- Go to `Logging ->  Cluster Flows`
- Click `Create` button and click second tab `Outputs`
- Click the `Cluster Outputs` options, it should show `Sorry, no matching options`.
- Same behavior to create `Flows`  

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![Screenshot 2025-01-20 at 1 35 49 PM (2)](https://github.com/user-attachments/assets/a2f997e5-6e44-4914-ae98-c8c7ae5b5aab)
![Screenshot 2025-01-20 at 1 48 17 PM (2)](https://github.com/user-attachments/assets/a0de8dbe-0047-4642-bffc-eb5979fe8dfb)
