### PR TITLE
The hints on the branding page is using the wrong product name

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -34,6 +34,11 @@ asyncButton:
     waiting: Restarting&hellip;
 
 harvester:
+  branding:
+    logos:
+      tip: 'Upload a logo to replace the Harvester logo in the top-level navigation header. Image height should be 21 pixels with a max width of 200 pixels. Max file size is 20KB. Accepted formats: JPEG, PNG, SVG.'
+    favicon:
+      tip: 'Upload an icon to replace the Harvester favicon in the browser tab. Max file size is 20KB'
   productLabel: 'Harvester'
   modal:
     backup:
@@ -1504,6 +1509,14 @@ harvester:
     addLabel: Add Workload Selector
     topologyKey:
       placeholder: 'topology.kubernetes.io/zone'
+
+typeDescription:
+  # Map of
+  # type: Description to be shown on the top of list view describing the type.
+  #       Should fit on one line.
+  #       If you link to anything external, it MUST have
+  #       target="_blank" rel="noopener noreferrer nofollow"
+  harvester: "Branding allows administrators to globally re-brand the UI by customizing the Harvester product name, logos and color scheme."
 
 advancedSettings:
   experimental: 'Experimental features allow users to test and evaluate early-access functionality prior to official supported releases'

--- a/pkg/harvester/pages/c/_cluster/brand/index.vue
+++ b/pkg/harvester/pages/c/_cluster/brand/index.vue
@@ -162,7 +162,7 @@ export default {
     <h1 class="mb-20">
       {{ t('branding.label') }}
     </h1>
-    <TypeDescription resource="branding" />
+    <TypeDescription resource="harvester" />
     <div>
       <div class="row mb-20">
         <div class="col span-6">
@@ -178,7 +178,7 @@ export default {
         {{ t('branding.logos.label') }}
       </h3>
       <label class="text-label">
-        {{ t('branding.logos.tip', {}, true) }}
+        {{ t('harvester.branding.logos.tip', {}, true) }}
       </label>
       <div class="row mt-10 mb-20">
         <Checkbox
@@ -242,7 +242,7 @@ export default {
         {{ t('branding.favicon.label') }}
       </h3>
       <label class="text-label">
-        {{ t('branding.favicon.tip', {}, true) }}
+        {{ t('harvester.branding.favicon.tip', {}, true) }}
       </label>
       <div class="row mt-10 mb-20">
         <Checkbox


### PR DESCRIPTION
### Summary
The hints on the Branding page at `Advanced > Settings > UI > branding` are using the product name `Rancher` instead of `Harvester`.

Related Issue 
https://github.com/harvester/harvester/issues/6341

### Screenshot/Video
After:
![Bildschirmfoto vom 2025-02-04 10-35-17](https://github.com/user-attachments/assets/acbe1c22-a242-4dff-a92f-7bf831ef5abb)
