### PR TITLE
fix: allow set empty for backupVolumeSnapshotClassName in Setting csi-driver-config

### DIFF
--- a/pkg/harvester/components/settings/csi-driver-config.vue
+++ b/pkg/harvester/components/settings/csi-driver-config.vue
@@ -161,6 +161,10 @@ export default {
       return driver === LONGHORN_DRIVER;
     },
 
+    isBackupVolumeSnapshotRequired(driver) {
+      return driver === LONGHORN_DRIVER;
+    },
+
     add() {
       this.configArr.push({
         key:   '',
@@ -217,7 +221,7 @@ export default {
           <LabeledSelect
             v-model="driver.value.backupVolumeSnapshotClassName"
             :mode="mode"
-            required
+            :required="isBackupVolumeSnapshotRequired(driver.key)"
             disabled
             :options="getVolumeSnapshotOptions(driver.key)"
             :label="t('harvester.setting.csiDriverConfig.backupVolumeSnapshotClassName')"

--- a/pkg/harvester/components/settings/csi-driver-config.vue
+++ b/pkg/harvester/components/settings/csi-driver-config.vue
@@ -138,7 +138,7 @@ export default {
             errors.push(this.t('validation.required', { key: this.t('harvester.setting.csiDriverConfig.volumeSnapshotClassName') }, true));
           }
 
-          if (!config.value.backupVolumeSnapshotClassName) {
+          if (config.key === LONGHORN_DRIVER && !config.value.backupVolumeSnapshotClassName) {
             errors.push(this.t('validation.required', { key: this.t('harvester.setting.csiDriverConfig.backupVolumeSnapshotClassName') }, true));
           }
         });
@@ -218,7 +218,7 @@ export default {
             v-model="driver.value.backupVolumeSnapshotClassName"
             :mode="mode"
             required
-            :disabled="disableEdit(driver.key)"
+            disabled
             :options="getVolumeSnapshotOptions(driver.key)"
             :label="t('harvester.setting.csiDriverConfig.backupVolumeSnapshotClassName')"
             @keydown.native.enter.prevent="()=>{}"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The `backupVolumeSnapshotClassName` should be grayed out directly for third-party storage.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @WebberHuang1118 

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG][GUI] Should Allow set empty for backupVolumeSnapshotClassName in Setting csi-driver-config #7737
](https://github.com/harvester/harvester/issues/7737#issuecomment-2700003551)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Navigate to Advanced → Settings → edit `csi-driver-config`
- Click `Add`, and the `Backup Volume Snapshot Class Name field` should be disabled
- Select the appropriate option, save and ensure it saves correctly

![Screenshot 2025-03-06 at 6 52 41 PM (2)](https://github.com/user-attachments/assets/bd93b3e1-3885-4ca7-94a5-c550a1c74899)

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

