### PR TITLE
fix: IPPool Config should provide same content as YAML

### DIFF
--- a/pkg/harvester/edit/loadbalancer.harvesterhci.io.ippool/Range.vue
+++ b/pkg/harvester/edit/loadbalancer.harvesterhci.io.ippool/Range.vue
@@ -27,7 +27,7 @@ export default {
     const rows = (this.value || []).map((row) => {
       let type = 'cidr';
 
-      if (row.rangeStart && row.rangeEnd) {
+      if (row.rangeStart || row.rangeEnd) {
         type = 'range';
       }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Update the range condition from `AND` to `OR`

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] IPPool Config should provide same content as YAML #6046](https://github.com/harvester/harvester/issues/6046)

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- The `Start IP` field should be displayed in the `range-subnet-start` config
![Screenshot 2025-05-15 at 12 53 04 PM (2)](https://github.com/user-attachments/assets/63be97df-5132-4e36-a3c6-7312c9c999dd)

- The `End IP` field should be displayed in the `range-subnet-end` config
![Screenshot 2025-05-15 at 12 53 01 PM (2)](https://github.com/user-attachments/assets/49aacdd2-c60f-4e2d-8b73-c00aab3fbcdb)
