### PR TITLE
fix(image): Correctly handle query parameters in image URL validation

### DIFF
--- a/pkg/harvester/validators/vm-image.js
+++ b/pkg/harvester/validators/vm-image.js
@@ -2,6 +2,35 @@ import { HCI } from '@pkg/harvester/config/labels-annotations';
 
 export const VM_IMAGE_FILE_FORMAT = ['qcow', 'qcow2', 'raw', 'img', 'iso'];
 
+/**
+ * Extracts the filename from a URL, handling query parameters and fragments
+ * @param {string} url - The URL to parse
+ * @returns {string} - The filename without query params or fragments
+ */
+function getFilenameFromUrl(url) {
+  try {
+    // Try to parse as a full URL
+    const urlObj = new URL(url);
+    // Get pathname and extract the last segment
+    const pathname = urlObj.pathname;
+    return pathname.split('/').pop() || '';
+  } catch (e) {
+    // If URL parsing fails, treat as a relative path
+    // Remove query params and fragments manually
+    const cleanUrl = url.split('?')[0].split('#')[0];
+    return cleanUrl.split('/').pop() || '';
+  }
+}
+
+/**
+ * Validates image URL format
+ * @param {string} url - The image URL to validate
+ * @param {object} getters - Vuex getters
+ * @param {array} errors - Array to collect validation errors
+ * @param {any} validatorArgs - Additional validator arguments
+ * @param {string} type - Type of validation ('file' or other)
+ * @returns {array} - Array of validation errors
+ */
 export function imageUrl(url, getters, errors, validatorArgs, type) {
   const t = getters['i18n/t'];
 
@@ -9,12 +38,20 @@ export function imageUrl(url, getters, errors, validatorArgs, type) {
     return errors;
   }
 
-  const suffixName = url.split('/').pop();
-  const fileSuffix = suffixName.split('.').pop().toLowerCase();
+  // Extract filename, handling query parameters and fragments
+  const filename = getFilenameFromUrl(url);
+  
+  if (!filename) {
+    const tipString = type === 'file' ? 'harvester.validation.image.ruleFileTip' : 'harvester.validation.image.ruleTip';
+    errors.push(t(tipString));
+    return errors;
+  }
+
+  // Get file extension
+  const fileSuffix = filename.split('.').pop().toLowerCase();
 
   if (!VM_IMAGE_FILE_FORMAT.includes(fileSuffix)) {
     const tipString = type === 'file' ? 'harvester.validation.image.ruleFileTip' : 'harvester.validation.image.ruleTip';
-
     errors.push(t(tipString));
   }
 


### PR DESCRIPTION
### Summary
The imageUrl validator currently fails to correctly extract the file extension when the image URL contains query parameters or fragments (e.g., 'image.qcow2?token=abc').

This change introduces a dedicated function, `getFilenameFromUrl`, which uses the native URL object for robust parsing. This ensures the file suffix validation is always performed on the actual filename, ignoring any trailing parameters.

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
    - [x] No
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
    - [x] No (This is a Harvester Dashboard specific component)
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:
    - [x] No (This is a purely front-end validation logic change)

Related Issue #
[5186](https://github.com/harvester/harvester/issues/5186)

### Occurred changes and/or fixed issues
Fixes an issue where image validation failed for URLs that contained query parameters (?) or fragments (#). The previous logic incorrectly included these trailing characters when attempting to determine the file extension, resulting in an invalid format error for a valid URL.

### Technical notes summary
A new private utility function, getFilenameFromUrl(url), was introduced. This function robustly parses the URL to ensure only the filename part of the path is used for validation.

It attempts to use the native URL object for standard-compliant parsing.

If parsing fails (e.g., if the input is a relative path), it falls back to manual string splitting to remove any query parameters (?) or fragments (#) before extracting the filename.

The main imageUrl validator now uses this new utility function before extracting the file suffix.

### Areas or cases that should be tested
Browser Used for Local Testing: [Your Browser, e.g., Chrome/Firefox/Edge]

Image Creation via URL: Test creating a new VM Image using a direct URL.

Case 1 (Success): Use a clean URL (e.g., http://example.com/image.qcow2).

Case 2 (Success - Fixed Case): Use a URL with a query parameter (e.g., http://example.com/image.qcow2?token=abc). This should succeed with no validation error.

Case 3 (Success - Fixed Case): Use a URL with a fragment (e.g., http://example.com/image.raw#latest). This should succeed with no validation error.

Validation Failure: Use a URL with an invalid extension and a query parameter (e.g., http://example.com/image.txt?param=1). This should fail and display the correct format validation error.

### Areas which could experience regressions
Any image creation/upload modal that uses the imageUrl validation function.

Other areas of image file validation (though the change is isolated to URL parsing).
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->