### PR TITLE
Respect StorageClass provisioner capabilities for PVC access modes

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.volume.vue
+++ b/pkg/harvester/edit/harvesterhci.io.volume.vue
@@ -22,6 +22,11 @@ import { STATE, NAME, AGE, NAMESPACE } from '@shell/config/table-headers';
 import { LVM_DRIVER } from '../models/harvester/storage.k8s.io.storageclass';
 import { DATA_ENGINE_V2 } from '../models/harvester/persistentvolumeclaim';
 
+const FILESYSTEM_RWO_PROVISIONERS = [
+  'csi.trident.netapp.io',
+  'disk.csi.everest.io',
+];
+
 export default {
   name: 'HarvesterVolume',
 
@@ -235,7 +240,11 @@ export default {
       let readWriteOnce = this.value.isLvm || this.value.isLonghornV2;
 
       if (storageClass) {
-        readWriteOnce = storageClass.provisioner === LVM_DRIVER || storageClass.parameters?.dataEngine === DATA_ENGINE_V2;
+        readWriteOnce = storageClass.provisioner === LVM_DRIVER || storageClass.parameters?.dataEngine === DATA_ENGINE_V2 ||
+        (
+          this.value.spec.volumeMode === 'Filesystem' &&
+        FILESYSTEM_RWO_PROVISIONERS.includes(storageClass.provisioner)
+        );
       }
 
       return readWriteOnce ? ['ReadWriteOnce'] : ['ReadWriteMany'];


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

#### PR Checklist
- Is this a multi-tenancy feature/bug?
    - [ ] Yes, the relevant RBAC changes are at:
- Do we need to backport changes to the [old Rancher UI](https://github.com/rancher/u), such as RKE1?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

Related Issue #
<!-- Define findings related to the feature or bug issue. -->
https://github.com/harvester/harvester/issues/9662

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- The [getAccessMode()](https://github.com/harvester/dashboard/blob/master/pkg/harvester/edit/harvesterhci.io.volume.vue#L231) method in HarvesterVolume.vue only checked for:

  - LVM driver
  - Longhorn V2
All other provisioners defaulted to ReadWriteMany, regardless of their actual capabilities.
Solution:

This change only adjusts access mode selection for filesystem volumes created using block-backed CSI drivers, avoiding RWX where unsupported

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

1. Create volume with NetApp Trident ONTAP SAN → PVC gets accessModes: ['ReadWriteOnce'] → Provisions successfully
2. Create volume with Longhorn → Still gets correct mode (RWO for V2, RWX for V1)
3. Create volume with LVM → Still gets ReadWriteOnce
4. Create volume with unknown provisioner → Defaults to ReadWriteMany (backward compatible)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->